### PR TITLE
fix(base-input): base input compatibility w/ firefox

### DIFF
--- a/packages/anu-vue/src/components/base-input/ABaseInput.tsx
+++ b/packages/anu-vue/src/components/base-input/ABaseInput.tsx
@@ -32,6 +32,7 @@ export const ABaseInput = defineComponent({
 
     const { class: rootClasses, ...inputAttrs } = attrs
 
+    // TODO(Enhancement): We might need to remove absolute added to html input element to retain width instead of providing min-w to below wrapper
     // TODO: We need to improve default slot implementation so that we can provide selected slot to selection component
     return () => <div class={['a-base-input-root i:children:focus-within:text-primary flex flex-col flex-grow flex-shrink-0', rootClasses ?? [], props.disabled && 'a-base-input-disabled ', (props.disabled || props.readonly) && 'pointer-events-none', !(props.disabled || props.readonly) && 'a-base-input-interactive']} ref={refRoot}>
             {/* 👉 Label */}
@@ -56,7 +57,7 @@ export const ABaseInput = defineComponent({
                 {/* SECTION Input wrapper */}
                 <div class={[
                     `${props.error ? 'border-danger' : 'focus-within:border-primary'}`,
-                    'a-base-input-input-wrapper relative i:focus-within:text-primary flex justify-center items-center border border-solid border-a-border w-full',
+                    'a-base-input-input-wrapper relative i:focus-within:text-primary items-center border border-solid border-a-border w-full',
                     props.inputWrapperClasses,
                 ]}>
 
@@ -72,7 +73,7 @@ export const ABaseInput = defineComponent({
                     {/* 👉 Slot: Default */}
                     {slots.default?.({
                       class: [
-                        'a-base-input-child w-full h-full rounded-inherit',
+                        'a-base-input-child w-full h-full absolute inset-0 rounded-inherit',
                         slots['prepend-inner'] || props.prependInnerIcon ? 'a-base-input-w-prepend-inner' : 'a-base-input-wo-prepend-inner',
                         slots['append-inner'] || props.appendInnerIcon ? 'a-base-input-w-append-inner' : 'a-base-input-wo-append-inner',
                       ],

--- a/packages/anu-vue/src/components/base-input/ABaseInput.tsx
+++ b/packages/anu-vue/src/components/base-input/ABaseInput.tsx
@@ -32,7 +32,6 @@ export const ABaseInput = defineComponent({
 
     const { class: rootClasses, ...inputAttrs } = attrs
 
-    // TODO(Enhancement): We might need to remove absolute added to html input element to retain width instead of providing min-w to below wrapper
     // TODO: We need to improve default slot implementation so that we can provide selected slot to selection component
     return () => <div class={['a-base-input-root i:children:focus-within:text-primary flex flex-col flex-grow flex-shrink-0', rootClasses ?? [], props.disabled && 'a-base-input-disabled ', (props.disabled || props.readonly) && 'pointer-events-none', !(props.disabled || props.readonly) && 'a-base-input-interactive']} ref={refRoot}>
             {/* 👉 Label */}
@@ -57,7 +56,7 @@ export const ABaseInput = defineComponent({
                 {/* SECTION Input wrapper */}
                 <div class={[
                     `${props.error ? 'border-danger' : 'focus-within:border-primary'}`,
-                    'a-base-input-input-wrapper relative i:focus-within:text-primary items-center border border-solid border-a-border w-full',
+                    'a-base-input-input-wrapper relative i:focus-within:text-primary flex justify-center items-center border border-solid border-a-border w-full',
                     props.inputWrapperClasses,
                 ]}>
 
@@ -73,7 +72,7 @@ export const ABaseInput = defineComponent({
                     {/* 👉 Slot: Default */}
                     {slots.default?.({
                       class: [
-                        'a-base-input-child absolute inset-0 rounded-inherit',
+                        'a-base-input-child w-full h-full rounded-inherit',
                         slots['prepend-inner'] || props.prependInnerIcon ? 'a-base-input-w-prepend-inner' : 'a-base-input-wo-prepend-inner',
                         slots['append-inner'] || props.appendInnerIcon ? 'a-base-input-w-append-inner' : 'a-base-input-wo-append-inner',
                       ],


### PR DESCRIPTION
Hey i was checking the project today it looks really awesome, was doing some testing on Firefox and seems like the input does not display as expected, added some changes to remove the absolute positioning in the html input, hopefully it's ok let me know if i need to change something

Before:
![2022-09-05 09 11 11](https://user-images.githubusercontent.com/47479471/188479448-bbf2d996-bd74-42d3-b262-808c24aac7c6.gif)

After:
![2022-09-05 09 12 38](https://user-images.githubusercontent.com/47479471/188479477-24c4ed5a-dfc9-4c01-b9e0-9e3ec470bafa.gif)

Firefox Browser Developer Edition 105.0b6 (64-bit)

EDIT: I see there's a problem with the select with this changes i will check how to fix it
EDIT 2: Added back absolute and just set `w-full` & `h-full`