### PR TITLE
fix(select): select don't get focus when arrow down is clicked

### DIFF
--- a/packages/anu-vue/src/components/select/ASelect.tsx
+++ b/packages/anu-vue/src/components/select/ASelect.tsx
@@ -28,6 +28,7 @@ export const ASelect = defineComponent({
     // SECTION Floating
     // Template refs
     const refReference = ref()
+    const selectRef = ref<HTMLSelectElement>()
     const refFloating = ref()
 
     const isOptionsVisible = ref(false)
@@ -86,9 +87,11 @@ export const ASelect = defineComponent({
 
     // TODO: You can use it as utility in another components
     // TODO: Add some style to indicate currently selected item
-    const openOptions = () => {
-      if (!(props.disabled || props.readonly))
+    const handleInputClick = () => {
+      if (!(props.disabled || props.readonly)) {
         isOptionsVisible.value = !isOptionsVisible.value
+        selectRef.value?.focus()
+      }
     }
 
     // 👉 Options
@@ -98,11 +101,10 @@ export const ASelect = defineComponent({
       emit('update:modelValue', option)
     }
 
-    // TODO: If we click on arrow down icon then select don't get primary border
     return () => <>
             {/* TODO: Make sure we don't bind input's `type` attr here */}
             <ABaseInput disabled={props.disabled} readonly={props.readonly} appendInnerIcon="i-bx-chevron-down" {...attrs} ref={refReference} inputContainerAttrs={{
-              onClick: openOptions,
+              onClick: handleInputClick,
             }}>
                 {{
                   // Recursively pass down slots
@@ -112,6 +114,7 @@ export const ASelect = defineComponent({
                             {...slotProps}
                             value={isObject(props.modelValue) && 'label' in props.modelValue && 'value' in props.modelValue ? (props.modelValue.label) : props.modelValue }
                             readonly
+                            ref={selectRef}
                         />,
                 }}
             </ABaseInput>


### PR DESCRIPTION
Based on TODO comment, I tried to fix `<ASelect />` border that doesn't get the primary color when the arrow down is clicked.

expected behaviour:
![Kapture 2022-09-10 at 20 14 51](https://user-images.githubusercontent.com/58697105/189497175-86f9ef01-c5f8-4af1-8fdb-cc6d5184b9aa.gif)

current behaviour:
![Kapture 2022-09-10 at 20 25 19](https://user-images.githubusercontent.com/58697105/189497202-cf2ed798-0007-4b82-8d08-7fc900c3d8d0.gif)

