### PR TITLE
feat!: assume `display: inline-block` as extraProperty in presetIcon

### DIFF
--- a/packages/anu-vue/src/components/base-input/ABaseInput.tsx
+++ b/packages/anu-vue/src/components/base-input/ABaseInput.tsx
@@ -64,7 +64,7 @@ export const ABaseInput = defineComponent({
                         slots['prepend-inner']
                           ? slots['prepend-inner']?.()
                           : props.prependInnerIcon
-                            ? <i class={['a-base-input-prepend-inner-icon inline-block', iconTransition, props.prependInnerIcon]} />
+                            ? <i class={['a-base-input-prepend-inner-icon', iconTransition, props.prependInnerIcon]} />
                             : null
                     }
 
@@ -84,7 +84,7 @@ export const ABaseInput = defineComponent({
                         slots['append-inner']
                           ? slots['append-inner']?.()
                           : props.appendInnerIcon
-                            ? <i class={['a-base-input-append-inner-icon inline-block ml-auto', iconTransition, props.appendInnerIcon]} />
+                            ? <i class={['a-base-input-append-inner-icon ml-auto', iconTransition, props.appendInnerIcon]} />
                             : null
                     }
                 </div>

--- a/packages/documentation/docs/guide/getting-started/installation.md
+++ b/packages/documentation/docs/guide/getting-started/installation.md
@@ -47,6 +47,7 @@
           extraProperties: {
             height: '1.5em',
             'flex-shrink': '0',
+            'display': 'inline-block',
           },
         }),
 

--- a/packages/documentation/uno.config.ts
+++ b/packages/documentation/uno.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
         // ℹ️ We also have to find a way to inject this without this config. (e.g. [class^=i-])
         'vertical-align': 'bottom',
         'flex-shrink': '0',
+        'display': 'inline-block',
 
         // We need to center the icon
         'margin-block': '0.15em',


### PR DESCRIPTION
I checked the following components, there is no any side effects when adding Add `display`: `inline-block` to extraProperties in `presetIcons`. But I have a question, `vitepress` has its own default style that overrides `anu-vue`, should we add a new playground to check it? For example, in `vitepress`, input supports dark mode, but I don't support it in my own project. In fact, `vitepress` configures the default background of input to be transparent, which will confuse us into thinking that `anu-vue` also supports it.

- [x] Alert
- [x] Avatar
- [x] Button
- [x] Card
- [x] Checkbox
- [x] Input
- [x] List
- [x] Select
- [x] Switch
- [x] Table