### PR TITLE
docs: refactored demos to use md container instead of HTML

### DIFF
--- a/packages/documentation/docs/demos/input/DemoInputBasic.vue
+++ b/packages/documentation/docs/demos/input/DemoInputBasic.vue
@@ -1,3 +1,7 @@
 <template>
-  <AInput />
+  <div class="grid-row sm:grid-cols-2 place-items-stretch">
+    <div>
+      <AInput />
+    </div>
+  </div>
 </template>

--- a/packages/documentation/docs/demos/input/DemoInputHint.vue
+++ b/packages/documentation/docs/demos/input/DemoInputHint.vue
@@ -1,7 +1,11 @@
 <template>
-  <AInput
-    id="demo-input-hint"
-    label="Email"
-    hint="Your email will be confidential"
-  />
+  <div class="grid-row sm:grid-cols-2 place-items-stretch">
+    <div>
+      <AInput
+        id="demo-input-hint"
+        label="Email"
+        hint="Your email will be confidential"
+      />
+    </div>
+  </div>
 </template>

--- a/packages/documentation/docs/demos/input/DemoInputPlaceholder.vue
+++ b/packages/documentation/docs/demos/input/DemoInputPlaceholder.vue
@@ -1,6 +1,10 @@
 <template>
-  <AInput
-    type="email"
-    placeholder="Enter your email"
-  />
+  <div class="grid-row sm:grid-cols-2 place-items-stretch">
+    <div>
+      <AInput
+        type="email"
+        placeholder="Enter your email"
+      />
+    </div>
+  </div>
 </template>

--- a/packages/documentation/docs/demos/input/DemoInputValidation.vue
+++ b/packages/documentation/docs/demos/input/DemoInputValidation.vue
@@ -7,10 +7,14 @@ const { errorMessage, value } = useField('fieldName', isRequired)
 </script>
 
 <template>
-  <AInput
-    v-model="value"
-    :error="errorMessage"
-    label="Username"
-    hint="Error message will get displayed here"
-  />
+  <div class="grid-row sm:grid-cols-2 place-items-stretch">
+    <div>
+      <AInput
+        v-model="value"
+        :error="errorMessage"
+        label="Username"
+        hint="Error message will get displayed here"
+      />
+    </div>
+  </div>
 </template>

--- a/packages/documentation/docs/demos/select/DemoSelectHint.vue
+++ b/packages/documentation/docs/demos/select/DemoSelectHint.vue
@@ -6,9 +6,13 @@ const fruits = ['banana', 'apple', 'watermelon', 'orange']
 </script>
 
 <template>
-  <ASelect
-    v-model="selected"
-    hint="We will deliver it shortly"
-    :options="fruits"
-  />
+  <div class="grid-row sm:grid-cols-2 justify-items-stretch">
+    <div>
+      <ASelect
+        v-model="selected"
+        hint="We will deliver it shortly"
+        :options="fruits"
+      />
+    </div>
+  </div>
 </template>

--- a/packages/documentation/docs/demos/select/DemoSelectLabel.vue
+++ b/packages/documentation/docs/demos/select/DemoSelectLabel.vue
@@ -6,9 +6,13 @@ const fruits = ['banana', 'apple', 'watermelon', 'orange']
 </script>
 
 <template>
-  <ASelect
-    v-model="selected"
-    label="Favorite Fruit"
-    :options="fruits"
-  />
+  <div class="grid-row sm:grid-cols-2 justify-items-stretch">
+    <div>
+      <ASelect
+        v-model="selected"
+        label="Favorite Fruit"
+        :options="fruits"
+      />
+    </div>
+  </div>
 </template>

--- a/packages/documentation/docs/demos/select/DemoSelectPlaceholder.vue
+++ b/packages/documentation/docs/demos/select/DemoSelectPlaceholder.vue
@@ -6,9 +6,13 @@ const fruits = ['banana', 'apple', 'watermelon', 'orange']
 </script>
 
 <template>
-  <ASelect
-    v-model="selected"
-    placeholder="Select Fruit"
-    :options="fruits"
-  />
+  <div class="grid-row sm:grid-cols-2 justify-items-stretch">
+    <div>
+      <ASelect
+        v-model="selected"
+        placeholder="Select Fruit"
+        :options="fruits"
+      />
+    </div>
+  </div>
 </template>

--- a/packages/documentation/docs/demos/table/DemoTableBasic.vue
+++ b/packages/documentation/docs/demos/table/DemoTableBasic.vue
@@ -29,5 +29,7 @@ const rows = [
 </script>
 
 <template>
-  <ATable :rows="rows" />
+  <div class="cards-demo-container">
+    <ATable :rows="rows" />
+  </div>
 </template>

--- a/packages/documentation/docs/demos/table/DemoTableColumnDefinition.vue
+++ b/packages/documentation/docs/demos/table/DemoTableColumnDefinition.vue
@@ -35,8 +35,10 @@ const columns = [
 </script>
 
 <template>
-  <ATable
-    :rows="rows"
-    :columns="columns"
-  />
+  <div class="cards-demo-container">
+    <ATable
+      :rows="rows"
+      :columns="columns"
+    />
+  </div>
 </template>

--- a/packages/documentation/docs/demos/table/DemoTableColumnFormatter.vue
+++ b/packages/documentation/docs/demos/table/DemoTableColumnFormatter.vue
@@ -35,8 +35,10 @@ const columns = [
 </script>
 
 <template>
-  <ATable
-    :rows="rows"
-    :columns="columns"
-  />
+  <div class="cards-demo-container">
+    <ATable
+      :rows="rows"
+      :columns="columns"
+    />
+  </div>
 </template>

--- a/packages/documentation/docs/demos/table/DemoTableColumnSlot.vue
+++ b/packages/documentation/docs/demos/table/DemoTableColumnSlot.vue
@@ -29,20 +29,22 @@ const rows = [
 </script>
 
 <template>
-  <ATable :rows="rows">
-    <!-- Name -->
-    <template #row-name="{ row }">
-      <span class="text-primary">
-        {{ row.name }}
-      </span>
-    </template>
+  <div class="cards-demo-container">
+    <ATable :rows="rows">
+      <!-- Name -->
+      <template #row-name="{ row }">
+        <span class="text-primary">
+          {{ row.name }}
+        </span>
+      </template>
 
-    <!-- Website -->
-    <template #row-website="{ row }">
-      <div class="flex gap-1 items-center">
-        <div class="i-bx-globe" />
-        {{ row.website }}
-      </div>
-    </template>
-  </ATable>
+      <!-- Website -->
+      <template #row-website="{ row }">
+        <div class="flex gap-1 items-center">
+          <div class="i-bx-globe" />
+          {{ row.website }}
+        </div>
+      </template>
+    </ATable>
+  </div>
 </template>

--- a/packages/documentation/docs/demos/table/DemoTableExtraColumn.vue
+++ b/packages/documentation/docs/demos/table/DemoTableExtraColumn.vue
@@ -35,34 +35,36 @@ const columns = [
 </script>
 
 <template>
-  <ATable
-    :rows="rows"
-    :columns="columns"
-  >
-    <template #row-actions>
-      <div class="flex items-center">
-        <ABtn
-          class="text-xs"
-          icon="i-bx-link-external"
-          icon-only
-          color="default"
-          variant="text"
-        />
-        <ABtn
-          class="text-xs"
-          icon="i-bx-edit-alt"
-          icon-only
-          variant="text"
-          color="default"
-        />
-        <ABtn
-          class="text-xs"
-          icon="i-bx-trash"
-          icon-only
-          variant="text"
-          color="default"
-        />
-      </div>
-    </template>
-  </ATable>
+  <div class="cards-demo-container">
+    <ATable
+      :rows="rows"
+      :columns="columns"
+    >
+      <template #row-actions>
+        <div class="flex items-center">
+          <ABtn
+            class="text-xs"
+            icon="i-bx-link-external"
+            icon-only
+            color="default"
+            variant="text"
+          />
+          <ABtn
+            class="text-xs"
+            icon="i-bx-edit-alt"
+            icon-only
+            variant="text"
+            color="default"
+          />
+          <ABtn
+            class="text-xs"
+            icon="i-bx-trash"
+            icon-only
+            variant="text"
+            color="default"
+          />
+        </div>
+      </template>
+    </ATable>
+  </div>
 </template>

--- a/packages/documentation/docs/demos/table/DemoTableFiltering.vue
+++ b/packages/documentation/docs/demos/table/DemoTableFiltering.vue
@@ -29,8 +29,10 @@ const rows = [
 </script>
 
 <template>
-  <ATable
-    :rows="rows"
-    search
-  />
+  <div class="cards-demo-container">
+    <ATable
+      :rows="rows"
+      search
+    />
+  </div>
 </template>

--- a/packages/documentation/docs/demos/table/DemoTableServerSideTable.vue
+++ b/packages/documentation/docs/demos/table/DemoTableServerSideTable.vue
@@ -335,10 +335,12 @@ const fetchItem = ({ q, currentPage, rowsPerPage, sortedCols }: ItemsFunctionPar
 </script>
 
 <template>
-  <ATable
-    :rows="fetchItem"
-    :columns="cols"
-    search
-    :page-size="5"
-  />
+  <div class="cards-demo-container">
+    <ATable
+      :rows="fetchItem"
+      :columns="cols"
+      search
+      :page-size="5"
+    />
+  </div>
 </template>

--- a/packages/documentation/docs/demos/table/DemoTableSorting.vue
+++ b/packages/documentation/docs/demos/table/DemoTableSorting.vue
@@ -29,5 +29,7 @@ const rows = [
 </script>
 
 <template>
-  <ATable :rows="rows" />
+  <div class="cards-demo-container">
+    <ATable :rows="rows" />
+  </div>
 </template>

--- a/packages/documentation/docs/guide/base-components/typography.md
+++ b/packages/documentation/docs/guide/base-components/typography.md
@@ -3,47 +3,33 @@
 <!-- TODO: Replace ABtn with AAvatar when ready. -->
 
 <!-- 👉 Basic -->
-<Demo>
-
-## Basic
+::::card Basic
 
 `ATypography` provides customizable typography for any needs.
 
 This will completely change how you work with typography.
 
-<DemoTypographyBasic />
-
-<template #code>
-
+:::code DemoTypographyBasic
 <<< @/demos/typography/DemoTypographyBasic.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Sizing -->
-<Demo>
-
-## Sizing
+::::card Sizing
 
 Want to create a list with title and subtitle no worries, Just add `text-sm`.
 
 You can use other font-size utilities to change typography size.
 
-<DemoTypographySizing />
-
-<template #code>
-
+:::code DemoTypographySizing
 <<< @/demos/typography/DemoTypographySizing.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Config Array -->
-<Demo>
-
-## Config Array
+::::card Config Array
 
 You can configure title, subtitle & text by passing array as prop instead of string.
 
@@ -51,12 +37,8 @@ First element of array will be treated as content and rest of them will be class
 
 It greatly improves DX and keep you code a bit DRY.
 
-<DemoTypographyConfigArray />
-
-<template #code>
-
+:::code DemoTypographyConfigArray
 <<< @/demos/typography/DemoTypographyConfigArray.vue
+:::
 
-</template>
-
-</Demo>
+::::

--- a/packages/documentation/docs/guide/components/alert.md
+++ b/packages/documentation/docs/guide/components/alert.md
@@ -1,107 +1,71 @@
 # Alert
 
 <!-- 👉 Light -->
-<Demo>
-
-## Light
+::::card Light
 
 `light` is default variant for alert.
 
-<DemoAlertLight />
-
-<template #code>
-
+:::code DemoAlertLight
 <<< @/demos/alert/DemoAlertLight.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Filled -->
-<Demo>
-
-## Filled
+::::card Filled
 
 You can use `variant="fill"` to create alert with filled background.
 
-<DemoAlertFilled />
-
-<template #code>
-
+:::code DemoAlertFilled
 <<< @/demos/alert/DemoAlertFilled.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Outlined -->
-<Demo>
-
-## Outlined
+::::card Outlined
 
 You can use `variant="outline"` to create outlined alert.
 
-<DemoAlertOutlined />
-
-<template #code>
-
+:::code DemoAlertOutlined
 <<< @/demos/alert/DemoAlertOutlined.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Icons -->
-<Demo>
-
-## Icons
+::::card Icons
 
 You can use `icon` prop to render icon in button.
 
 Use `append-icon` prop to render icon after default slot.
 
-<DemoAlertIcons />
-
-<template #code>
-
+:::code DemoAlertIcons
 <<< @/demos/alert/DemoAlertIcons.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Dismissible -->
-<Demo>
-
-## Dismissible
+::::card Dismissible
 
 Use `dismissible` prop to create dismissible alert.
 
 You can customize close icon using `append-icon` prop.
 
-<DemoAlertDismissible />
-
-<template #code>
-
+:::code DemoAlertDismissible
 <<< @/demos/alert/DemoAlertDismissible.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 v-model support -->
-<Demo>
-
-## v-model support
+::::card v-model support
 
 Alert also support `v-model` to show and hide alert based on model value.
 
-<DemoAlertVModelSupport />
-
-<template #code>
-
+:::code DemoAlertVModelSupport
 <<< @/demos/alert/DemoAlertVModelSupport.vue
+:::
 
-</template>
-
-</Demo>
+::::

--- a/packages/documentation/docs/guide/components/avatar.md
+++ b/packages/documentation/docs/guide/components/avatar.md
@@ -1,86 +1,55 @@
 # Avatar
 
 <!-- 👉 Default -->
-<Demo>
-
-## Default
+::::card Default
 
 Default variant for avatar is `light`
 
-<DemoAvatarDefault />
-
-<template #code>
-
+:::code DemoAvatarDefault
 <<< @/demos/avatar/DemoAvatarDefault.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Fill -->
-<Demo>
-
-## Fill
+::::card Fill
 
 You can use `variant="fill"` to create avatar with filled background
 
-<DemoAvatarFill />
-
-<template #code>
-
+:::code DemoAvatarFill
 <<< @/demos/avatar/DemoAvatarFill.vue
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Outlined -->
-<Demo>
-
-## Outlined
+::::card Outlined
 
 You can use variant="outline" to create outlined avatar
 
-<DemoAvatarOutlined />
-
-<template #code>
-
+:::code DemoAvatarOutlined
 <<< @/demos/avatar/DemoAvatarOutlined.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Sizing -->
-<Demo>
-
-## Sizing
+::::card Sizing
 
 You can use font-size utility to adjust the size of avatar
 
-<DemoAvatarSizing />
-
-<template #code>
-
+:::code DemoAvatarSizing
 <<< @/demos/avatar/DemoAvatarSizing.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Roundness -->
-<Demo>
-
-## Roundness
+::::card Roundness
 
 You can adjust avatar roundness using border-radius utilities
 
-<DemoAvatarRoundness />
-
-<template #code>
-
+:::code DemoAvatarRoundness
 <<< @/demos/avatar/DemoAvatarRoundness.vue
+:::
 
-</template>
-
-</Demo>
+::::

--- a/packages/documentation/docs/guide/components/button.md
+++ b/packages/documentation/docs/guide/components/button.md
@@ -11,21 +11,15 @@
 :::
 
 <!-- 👉 Outlined -->
-<Demo>
-
-## Outlined
+::::card Outlined
 
 You can use `variant="outline"` to create outlined button.
 
-<DemoButtonOutlined />
-
-<template #code>
-
+:::code DemoButtonOutlined
 <<< @/demos/button/DemoButtonOutlined.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 :::details Customize `border-style` of outlined buttons
 To create outlined button with different border style just add relevant class.
@@ -34,50 +28,39 @@ e.g. To create outline button with dashed border, add `border-dashed` class.
 :::
 
 <!-- 👉 Light -->
-<Demo>
-
-## Light
+::::card Light
 
 You can use `variant="light"` to create button with light background _(Background with opacity)_.
 
-<DemoButtonLight />
-
-<template #code>
-
+:::code DemoButtonLight
 <<< @/demos/button/DemoButtonLight.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Text -->
-<Demo>
-
-## Text
+::::card Text
 
 Use `variant="text"` to create a text button.
 
-<DemoButtonText />
-
-<template #code>
-
+:::code DemoButtonText
 <<< @/demos/button/DemoButtonText.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Icons -->
-<Demo>
-
-## Icons
+::::card Icons
 
 You can use `icon` prop to render icon in button.
 
 Use `append-icon` prop to render icon after default slot.
 
-<DemoButtonIcons />
+:::code DemoButtonIcons
+<<< @/demos/button/DemoButtonIcons.vue
+:::
 
+::::
 :::details You can also use default slot to render icon.
 
 ```vue
@@ -91,82 +74,50 @@ Use `append-icon` prop to render icon after default slot.
 
 :::
 
-<template #code>
-
-<<< @/demos/button/DemoButtonIcons.vue
-
-</template>
-
-</Demo>
-
 <!-- 👉 Block -->
-<Demo>
-
-## Block
+::::card Block
 
 Add `w-full` class to make block button.
 
-<DemoButtonBlock />
-
-<template #code>
-
+:::code DemoButtonBlock
 <<< @/demos/button/DemoButtonBlock.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Icon Only -->
-<Demo>
-
-## Icon Only
+::::card Icon Only
 
 Use `icon-only` prop to render icon with icon only button.
 
-<DemoButtonIconOnly />
-
-<template #code>
-
+:::code DemoButtonIconOnly
 <<< @/demos/button/DemoButtonIconOnly.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Sizing -->
-<Demo>
-
-## Sizing
+::::card Sizing
 
 You can use font-size utility to adjust the size of button.
 
-<DemoButtonSizing />
+:::code DemoButtonSizing
+<<< @/demos/button/DemoButtonSizing.vue
+:::
+
+::::
 
 :::tip
 If you have container with bigger font size and need default sized button use `text-base` class.
 :::
 
-<template #code>
-
-<<< @/demos/button/DemoButtonSizing.vue
-
-</template>
-
-</Demo>
-
 <!-- 👉 Roundness -->
-<Demo>
-
-## Roundness
+::::card Roundness
 
 You can adjust button roundness using border-radius utilities.
 
-<DemoButtonRoundness />
-
-<template #code>
-
+:::code DemoButtonRoundness
 <<< @/demos/button/DemoButtonRoundness.vue
+:::
 
-</template>
-
-</Demo>
+::::

--- a/packages/documentation/docs/guide/components/button.md
+++ b/packages/documentation/docs/guide/components/button.md
@@ -1,14 +1,15 @@
 # Button
 
 <!-- 👉 Filled -->
-:::card Filled
+::::card Filled
 
 `fill` is default variant for button.
 
 :::code DemoButtonFilled
 <<< @/demos/button/DemoButtonFilled.vue
-
 :::
+
+::::
 
 <!-- 👉 Outlined -->
 ::::card Outlined

--- a/packages/documentation/docs/guide/components/card.md
+++ b/packages/documentation/docs/guide/components/card.md
@@ -1,9 +1,7 @@
 # Card
 
 <!-- 👉 Basic -->
-<Demo>
-
-## Basic
+::::card Basic
 
 Card component uses [`ATypography`](/guide/base-components/typography) component for its typography.
 
@@ -11,72 +9,48 @@ Moreover, you can also use `.card-body` in default slot to render card content.
 
 You can use `.card-spacer` helper class to add margin bottom to each of its children except last.
 
-<DemoCardBasic />
-
-<template #code>
-
+:::code DemoCardBasic
 <<< @/demos/card/DemoCardBasic.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 :::tip
 You can customize the applied `margin-bottom` by configuring `--a-card-spacer` CSS variable.
 :::
 
 <!-- 👉 Various Elements -->
-<Demo>
-
-## Various Elements
+::::card Various Elements
 
 Mix and match the different components to achieve desired UI.
 
-<template #demo>
-    <DemoCardVariousElements />
-</template>
-
-<template #code>
-
+:::code DemoCardVariousElements
 <<< @/demos/card/DemoCardVariousElements.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Variants -->
-<Demo>
-
-## Variants
+::::card Variants
 
 Card component uses layer composable as it's base. You can use `variant` prop to create various card variants.
 
-<DemoCardVariants />
-
-<template #code>
-
+:::code DemoCardVariants
 <<< @/demos/card/DemoCardVariants.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Slot -->
-<Demo>
-
-## Slot
+::::card Slot
 
 You can use `ATypography` slots to render custom content in header.
 
-<DemoCardSlot />
-
-<template #code>
-
+:::code DemoCardSlot
 <<< @/demos/card/DemoCardSlot.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 :::tip
 Above demo adds content to the right of title. If you want to add content on the right of both title & subtitle use `headerRight` slot.

--- a/packages/documentation/docs/guide/components/checkbox.md
+++ b/packages/documentation/docs/guide/components/checkbox.md
@@ -1,67 +1,43 @@
 # Checkbox
 
 <!-- 👉 Basic -->
-<Demo>
+::::card Basic
 
-## Basic
-
-<DemoCheckboxBasic />
-
-<template #code>
-
+:::code DemoCheckboxBasic
 <<< @/demos/checkbox/DemoCheckboxBasic.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Icon -->
-<Demo>
-
-## Icon
+::::card Icon
 
 Use `icon` prop to change the checked icon.
 
-<DemoCheckboxIcon />
-
-<template #code>
-
+:::code DemoCheckboxIcon
 <<< @/demos/checkbox/DemoCheckboxIcon.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Array -->
-<Demo>
-
-## Array
+::::card Array
 
 `ACheckbox` also support arrays like a native checkbox.
 
-<DemoCheckboxArray />
-
-<template #code>
-
+:::code DemoCheckboxArray
 <<< @/demos/checkbox/DemoCheckboxArray.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Color -->
-<Demo>
-
-## Color
+::::card Color
 
 You can use `color` prop to change the checkbox color.
 
-<DemoCheckboxColor />
-
-<template #code>
-
+:::code DemoCheckboxColor
 <<< @/demos/checkbox/DemoCheckboxColor.vue
+:::
 
-</template>
-
-</Demo>
+::::

--- a/packages/documentation/docs/guide/components/dialog.md
+++ b/packages/documentation/docs/guide/components/dialog.md
@@ -1,23 +1,17 @@
 # Dialog
 
 <!-- 👉 Basic -->
-<Demo>
-
-## Basic
+::::card Basic
 
 `ADialog` component uses `ACard` as its base. Bind `ADialog` with `v-model` to hide and show dialog/card.
 
 All props & slots available in `ACard` is available in `ADialog`.
 
-<DemoDialogBasic />
-
-<template #code>
-
+:::code DemoDialogBasic
 <<< @/demos/dialog/DemoDialogBasic.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Placement -->
 <!-- <Demo>
@@ -39,35 +33,23 @@ You can adjust dialog placement via `place-items-start top-16 justify-center` cl
 </Demo> -->
 
 <!-- 👉 Width -->
-<Demo>
-
-## Width
+::::card Width
 
 Use width utility classes to provide custom width to dialog. e.g. `w-[800px]`.
 
-<DemoDialogWidth />
-
-<template #code>
-
+:::code DemoDialogWidth
 <<< @/demos/dialog/DemoDialogWidth.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Persistent -->
-<Demo>
-
-## Persistent
+::::card Persistent
 
 You can disable closing dialog on outside click via `persistent` prop.
 
-<DemoDialogPersistent />
-
-<template #code>
-
+:::code DemoDialogPersistent
 <<< @/demos/dialog/DemoDialogPersistent.vue
+:::
 
-</template>
-
-</Demo>
+::::

--- a/packages/documentation/docs/guide/components/drawer.md
+++ b/packages/documentation/docs/guide/components/drawer.md
@@ -1,71 +1,47 @@
 # Drawer
 
 <!-- 👉 Basic -->
-<Demo>
-
-## Basic
+::::card Basic
 
 `ADrawer` component uses `ACard` as its base. Bind `ADrawer` with `v-model` to hide and show drawer/card.
 
 All props & slots available in `ACard` is available in `ADrawer`.
 
-<DemoDrawerBasic />
-
-<template #code>
-
+:::code DemoDrawerBasic
 <<< @/demos/drawer/DemoDrawerBasic.vue{8-12}
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Anchor -->
-<Demo>
-
-## Anchor
+::::card Anchor
 
 You can change the position of the drawer by providing the values `left` or `right` to the `anchor` prop.
 
-<DemoDrawerAnchor />
-
-<template #code>
-
+:::code DemoDrawerAnchor
 <<< @/demos/drawer/DemoDrawerAnchor.vue{22,30}
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Width -->
-<Demo>
-
-## Width
+::::card Width
 
 Use width utility classes to provide custom width to drawer. e.g. `w-[400px]`.
 
-<DemoDrawerWidth />
-
-<template #code>
-
+:::code DemoDrawerWidth
 <<< @/demos/drawer/DemoDrawerWidth.vue{12}
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Persistent -->
-<Demo>
-
-## Persistent
+::::card Persistent
 
 You can disable closing drawer on outside click via `persistent` prop.
 
-<DemoDrawerPersistent />
-
-<template #code>
-
+:::code DemoDrawerPersistent
 <<< @/demos/drawer/DemoDrawerPersistent.vue{13}
+:::
 
-</template>
-
-</Demo>
+::::

--- a/packages/documentation/docs/guide/components/input.md
+++ b/packages/documentation/docs/guide/components/input.md
@@ -1,203 +1,127 @@
 # Input
 
 <!-- 👉 Basic -->
-<Demo>
-
-## Basic
+::::card Basic
 
 You can use `AInput` component to render basic input.
 
-<div class="grid-row sm:grid-cols-2 place-items-stretch">
-    <div>
-        <DemoInputBasic />
-    </div>
-</div>
-
-<template #code>
-
+:::code DemoInputBasic
 <<< @/demos/input/DemoInputBasic.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Placeholder -->
-<Demo>
-
-## Placeholder
+::::card Placeholder
 
 You can use `placeholder` attribute to add placeholder to the input.
 
-<div class="grid-row sm:grid-cols-2 place-items-stretch">
-    <div>
-        <DemoInputPlaceholder />
-    </div>
-</div>
-
-<template #code>
-
+:::code DemoInputPlaceholder
 <<< @/demos/input/DemoInputPlaceholder.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Label -->
-<Demo>
-
-## Label
+::::card Label
 
 You can use `label` prop to add label to the input.
 
 For maximum flexibility you can use `label` slot.
 
-<DemoInputLabel />
+:::code DemoInputLabel
+<<< @/demos/input/DemoInputLabel.vue{11,16}
+:::
+
+::::
 
 :::warning
 When you use **label slot**, Note that label's `for` attribute needs to prefix the `a-input-` when binding it to input's `id` attribute.
 :::
 
-<template #code>
-
-<<< @/demos/input/DemoInputLabel.vue{11,16}
-
-</template>
-
-</Demo>
-
 <!-- 👉 Hint -->
-<Demo>
-
-## Hint
+::::card Hint
 
 You can use `hint` prop to add hint to the input.
 
-<div class="grid-row sm:grid-cols-2 place-items-stretch">
-    <div>
-        <DemoInputHint />
-    </div>
-</div>
-
-<template #code>
-
+:::code <
 <<< @/demos/input/DemoInputHint.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Icons -->
-<Demo>
-
-## Icons
+::::card Icons
 
 You can use various icon location prop to add icon to the input.
 
-<DemoInputIcons />
-
-<template #code>
-
+:::code DemoInputIcons
 <<< @/demos/input/DemoInputIcons.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Sizing -->
-<Demo>
-
-## Sizing
+::::card Sizing
 
 You can use font-size utility to adjust the size of input.
 
-<DemoInputSizing />
-
-<template #code>
-
+:::code DemoInputSizing
 <<< @/demos/input/DemoInputSizing.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 :::tip
 Like `AInput`, `ASelect` & `ATextarea` also built on top of `ABaseInput` base component. Hence, This demo also applies to `ASelect` & `ATextarea`.
 :::
 
 <!-- 👉 Roundness -->
-<Demo>
-
-## Roundness
+::::card Roundness
 
 You can adjust input roundness by providing border-radius utilities to `input-wrapper-classes` prop.
 
-<DemoInputRoundness />
-
-<template #code>
-
+:::code DemoInputRoundness
 <<< @/demos/input/DemoInputRoundness.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 :::tip
 Like `AInput`, `ASelect` & `ATextarea` also built on top of `ABaseInput` base component. Hence, This demo also applies to `ASelect` & `ATextarea`.
 :::
 
 <!-- 👉 Types -->
-<Demo>
-
-## Types
+::::card Types
 
 You can use `type` attribute to add input type.
 
-<DemoInputTypes />
-
-<template #code>
-
+:::code DemoInputTypes
 <<< @/demos/input/DemoInputTypes.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 States -->
-<Demo>
-
-## States
+::::card States
 
 You can use `readonly` prop to make input read only.
 
 Use `disabled` prop to make input disabled.
 
-<DemoInputStates />
-
-<template #code>
-
+:::code DemoInputStates
 <<< @/demos/input/DemoInputStates.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Validation -->
-<Demo>
-
-## Validation
+::::card Validation
 
 Anu do not provide any validation mechanism at the moment as it assume it's better handled by third-party libraries like [VeeValidate](https://vee-validate.logaretm.com/)
 
-<div class="grid-row sm:grid-cols-2 place-items-stretch">
-    <div>
-        <DemoInputValidation />
-    </div>
-</div>
-
-<template #code>
-
+:::code DemoInputValidation
 <<< @/demos/input/DemoInputValidation.vue
+:::
 
-</template>
-
-</Demo>
+::::

--- a/packages/documentation/docs/guide/components/input.md
+++ b/packages/documentation/docs/guide/components/input.md
@@ -44,7 +44,7 @@ When you use **label slot**, Note that label's `for` attribute needs to prefix t
 
 You can use `hint` prop to add hint to the input.
 
-:::code <
+:::code DemoInputHint
 <<< @/demos/input/DemoInputHint.vue
 :::
 

--- a/packages/documentation/docs/guide/components/list.md
+++ b/packages/documentation/docs/guide/components/list.md
@@ -1,113 +1,73 @@
 # List
 
 <!-- 👉 Basic -->
-<Demo>
-
-## Basic
+::::card Basic
 
 `AList` is fully customizable and provides easy to use API to render list. It support `ATypography` props to render text quickly.
 
 You can also use `default` slot to render your custom content if you don't want to use typography props.
 
-<template #demo>
-    <DemoListBasic />
-</template>
-
-<template #code>
-
+:::code DemoListBasic
 <<< @/demos/list/DemoListBasic.vue{2-7,13}
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Slots -->
-<Demo>
-
-## Slots
+::::card Slots
 
 Use `before` & `after` slot to add custom content before and after list items. There's also `prepend` & `append` slot for list item to append & prepend custom content.
 
-<template #demo>
-    <DemoListSlots />
-</template>
-
-<template #code>
-
+:::code DemoListSlots
 <<< @/demos/list/DemoListSlots.vue{18-20,23-32,35-41}
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Avatar -->
-<Demo>
-
-## Avatar
+::::card Avatar
 
 You can also pass avatar props like `icon` to list item as property to render the desired avatar without writing extra markup.
 
 Moreover, to customize the avatar itself you can use `$avatar` property. E.g. Pass the `class` or another any prop/attribute.
 
-<template #demo>
-    <DemoListAvatar />
-</template>
-
-<template #code>
-
+:::code DemoListAvatar
 <<< @/demos/list/DemoListAvatar.vue{4,7,10,13,16,19,22,25}
+:::
 
-</template>
-
-</Demo>
+::::
 
 :::tip Taking flexibility to next level 🚀
 For maximum flexibility, `AList` also provides `avatar-append` boolean prop to tell `AList` to render the avatar at the end instead of at start.
 :::
 
 <!-- 👉 `v-model` Support -->
-<Demo>
-
-## `v-model` Support
+::::card `v-model` Support
 
 `AList` also support `v-model`. Use any value other than `null` to enable the `v-model` support.
 
 If you don't provide `value` property to each list item, `AList` will emit list item's index as selected value.
 
-<template #demo>
-    <DemoListVModelSupport />
-</template>
-
-<template #code>
-
+:::code DemoListVModelSupport
 <<< @/demos/list/DemoListVModelSupport.vue{11,18}
+:::
 
-</template>
-
-</Demo>
+::::
 
 :::tip
 For selection, `AList` uses [`useGroupModel`](/guide/composables/useGroupModel). Hence, you can also use the `multi` prop to allow multiple selection.
 :::
 
 <!-- 👉 Variants -->
-<Demo>
-
-## Variants
+::::card Variants
 
 `AList` also accepts layer props like `variant`, `color` & `states` to change the appearance of list.
 
-<template #demo>
-    <DemoListVariants />
-</template>
-
-<template #code>
-
+:::code DemoListVariants
 <<< @/demos/list/DemoListVariants.vue{20}
+:::
 
-</template>
-
-</Demo>
+::::
 
 :::tip
 Use `a-list-items-pill` to create pill shaped list items. It just modifies some CSS to achieve the pill UI.

--- a/packages/documentation/docs/guide/components/radio.md
+++ b/packages/documentation/docs/guide/components/radio.md
@@ -1,35 +1,23 @@
 # Radio
 
 <!-- 👉 Basic -->
-<Demo>
-
-## Basic
+::::card Basic
 
 Use `label` prop to set the label.
 
-<DemoRadioBasic />
-
-<template #code>
-
+:::code DemoRadioBasic
 <<< @/demos/radio/DemoRadioBasic.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Color -->
-<Demo>
-
-## Color
+::::card Color
 
 Use `color` prop to change the radio color.
 
-<DemoRadioColor />
-
-<template #code>
-
+:::code DemoRadioColor
 <<< @/demos/radio/DemoRadioColor.vue
+:::
 
-</template>
-
-</Demo>
+::::

--- a/packages/documentation/docs/guide/components/select.md
+++ b/packages/documentation/docs/guide/components/select.md
@@ -1,89 +1,51 @@
 # Select
 
 <!-- 👉 Basic -->
-<Demo>
-
-## Basic
+::::card Basic
 
 You can use `ASelect` component to render basic select.
 
-<DemoSelectBasic />
-
-<template #code>
-
+:::code DemoSelectBasic
 <<< @/demos/select/DemoSelectBasic.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Placeholder -->
-<Demo>
-
-## Placeholder
+::::card Placeholder
 
 You can use `placeholder` attribute to add placeholder to the select.
 
-<div class="grid-row sm:grid-cols-2 justify-items-stretch">
-    <div>
-        <DemoSelectPlaceholder />
-    </div>
-</div>
-
-<template #code>
-
+:::code DemoSelectPlaceholder
 <<< @/demos/select/DemoSelectPlaceholder.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Label -->
-<Demo>
-
-## Label
+::::card Label
 
 You can use `label` prop to add label to the select.
 
-<div class="grid-row sm:grid-cols-2 justify-items-stretch">
-    <div>
-        <DemoSelectLabel />
-    </div>
-</div>
-
-<template #code>
-
+:::code DemoSelectLabel
 <<< @/demos/select/DemoSelectLabel.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Hint -->
-<Demo>
-
-## Hint
+::::card Hint
 
 You can use `hint` prop to add hint to the select.
 
-<div class="grid-row sm:grid-cols-2 justify-items-stretch">
-    <div>
-        <DemoSelectHint />
-    </div>
-</div>
-
-<template #code>
-
+:::code DemoSelectHint
 <<< @/demos/select/DemoSelectHint.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Icons -->
-<Demo>
-
-## Icons
+::::card Icons
 
 You can use `append-inner-icon` prop to change icon of the select component.
 
@@ -91,48 +53,32 @@ To prepend the icon use `prepend-inner-icon` prop.
 
 Moreover, you can also use `append-icon` & `prepend-icon` prop to add icon outside of the select component.
 
-<DemoSelectIcons />
-
-<template #code>
-
+:::code DemoSelectIcons
 <<< @/demos/select/DemoSelectIcons.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Slots -->
-<Demo>
-
-## Slot
+::::card Slot
 
 You can use default slot to render the `ASelect` options. Don't forget to bind `attrs` from [slotProps](https://vuejs.org/guide/components/slots.html#scoped-slots) to looping element.
 
-<DemoSelectSlot />
-
-<template #code>
-
+:::code DemoSelectSlot
 <<< @/demos/select/DemoSelectSlot.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 States -->
-<Demo>
-
-## States
+::::card States
 
 You can use `readonly` prop to make select read only.
 
 Use `disabled` prop to make select disabled.
 
-<DemoSelectStates />
-
-<template #code>
-
+:::code DemoSelectStates
 <<< @/demos/select/DemoSelectStates.vue
+:::
 
-</template>
-
-</Demo>
+::::

--- a/packages/documentation/docs/guide/components/switch.md
+++ b/packages/documentation/docs/guide/components/switch.md
@@ -1,43 +1,29 @@
 # Switch
 
 <!-- 👉 Basic -->
-<Demo>
-
-## Basic
+::::card Basic
 
 Use `ASwitch` component to create toggle for boolean value.
 
-<DemoSwitchBasic />
-
-<template #code>
-
+:::code DemoSwitchBasic
 <<< @/demos/switch/DemoSwitchBasic.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Colors -->
-<Demo>
-
-## Colors
+::::card Colors
 
 You can use `color` prop to change the switch color
 
-<DemoSwitchColors />
-
-<template #code>
-
+:::code DemoSwitchColors
 <<< @/demos/switch/DemoSwitchColors.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Label -->
-<Demo>
-
-## Label
+::::card Label
 
 You can use `label` prop to add label to switch component.
 
@@ -45,84 +31,56 @@ Label and switch have `justify-between` added as this is how generally used but 
 
 <br>
 
-<DemoSwitchLabel />
-
-<template #code>
-
+:::code DemoSwitchLabel
 <<< @/demos/switch/DemoSwitchLabel.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 :::tip
 You can also use default slot to render the label
 :::
 
 <!-- 👉 Icons -->
-<Demo>
-
-## Icons
+::::card Icons
 
 Use `on-icon` & `off-icon` prop to render icons inside switch dot.
 
-<DemoSwitchIcons />
-
-<template #code>
-
+:::code DemoSwitchIcons
 <<< @/demos/switch/DemoSwitchIcons.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Sizing -->
-<Demo>
-
-## Sizing
+::::card Sizing
 
 You can use font-size utility to adjust the size of switch
 
-<DemoSwitchSizing />
-
-<template #code>
-
+:::code DemoSwitchSizing
 <<< @/demos/switch/DemoSwitchSizing.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 States -->
-<Demo>
-
-## States
+::::card States
 
 You can use `disabled` prop to disable the switch
 
-<DemoSwitchStates />
-
-<template #code>
-
+:::code DemoSwitchStates
 <<< @/demos/switch/DemoSwitchStates.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Roundness -->
-<Demo>
-
-## Roundness
+::::card Roundness
 
 You can adjust switch roundness using border-radius utilities
 
-<DemoSwitchRoundness />
-
-<template #code>
-
+:::code DemoSwitchRoundness
 <<< @/demos/switch/DemoSwitchRoundness.vue
+:::
 
-</template>
-
-</Demo>
+::::

--- a/packages/documentation/docs/guide/components/table.md
+++ b/packages/documentation/docs/guide/components/table.md
@@ -1,116 +1,64 @@
 # Table
 
 <!-- 👉 Basic -->
-<Demo>
-
-## Basic
+::::card Basic
 
 Use `rows` prop to provide data to `ATable`. Defining columns for table is optional. When columns aren't specified, columns will get calculate from first row and all columns will be filterable and sortable.
 
-<template #demo>
-    <div class="cards-demo-container">
-        <DemoTableBasic />
-    </div>
-</template>
-
-<template #code>
-
+:::code DemoTableBasic
 <<< @/demos/table/DemoTableBasic.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Column Definition -->
-<Demo>
-
-## Column Definition
+::::card Column Definition
 
 You can use `columns` prop to define columns for the table.
 
-<template #demo>
-    <div class="cards-demo-container">
-        <DemoTableColumnDefinition />
-    </div>
-</template>
-
-<template #code>
-
+:::code DemoTableColumnDefinition
 <<< @/demos/table/DemoTableColumnDefinition.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Column Formatter -->
-<Demo>
-
-## Column Formatter
+::::card Column Formatter
 
 Use `formatter` property while defining column to format the column text.
 
-<template #demo>
-    <div class="cards-demo-container">
-        <DemoTableColumnFormatter />
-    </div>
-</template>
-
-<template #code>
-
+:::code DemoTableColumnFormatter
 <<< @/demos/table/DemoTableColumnFormatter.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Column Slot -->
-<Demo>
-
-## Column Slot
+::::card Column Slot
 
 `ATable` generates scoped slot based on your column name. If your column name is `website` then you can use `row-website` scoped slot to render custom content in your column.
 
-<template #demo>
-    <div class="cards-demo-container">
-        <DemoTableColumnSlot />
-    </div>
-</template>
-
-<template #code>
-
+:::code DemoTableColumnSlot
 <<< @/demos/table/DemoTableColumnSlot.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Filtering -->
-<Demo>
-
-## Filtering
+::::card Filtering
 
 Set `search` prop to `true` to enable table filtering.
 
 Search will respect the column's `isFilterable` property to include or exclude the column from searching. If you don't specify column defination all columns will be filterable.
 
-<template #demo>
-    <div class="cards-demo-container">
-        <DemoTableFiltering />
-    </div>
-</template>
-
-<template #code>
-
+:::code DemoTableFiltering
 <<< @/demos/table/DemoTableFiltering.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Sorting -->
-<Demo>
-
-## Sorting
+::::card Sorting
 
 Sorting is enable by default and will respect the column's `isSortable` property. If you don't specify column definition all columns will be sortable.
 
@@ -118,47 +66,27 @@ To disable sorting on table use set `isSortable` prop to `false` on `ATable`.
 
 Moreover, You can also sort multiple columns at once. You can enable it by setting `multiSort` prop to `true` on `ATable`.
 
-<template #demo>
-    <div class="cards-demo-container">
-        <DemoTableSorting />
-    </div>
-</template>
-
-<template #code>
-
+:::code DemoTableSorting
 <<< @/demos/table/DemoTableSorting.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Extra Column -->
-<Demo>
-
-## Extra Column
+::::card Extra Column
 
 Define extra column in column definition to add column to table. Later, you can use column slot `row-<name>` to render your custom content.
 
 Moreover, you can also omit the column definition to omit rendering the specific column.
 
-<template #demo>
-    <div class="cards-demo-container">
-        <DemoTableExtraColumn />
-    </div>
-</template>
-
-<template #code>
-
+:::code DemoTableExtraColumn
 <<< @/demos/table/DemoTableExtraColumn.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Server Side Table -->
-<Demo>
-
-## Server Side Table
+::::card Server Side Table
 
 If your table data is coming from API/backend you can pass async function to `rows` prop which should resolve the below type:
 
@@ -182,16 +110,8 @@ const fetchRows = ({ q, currentPage, rowsPerPage, sortedCols }) => {
 }
 ```
 
-<template #demo>
-    <div class="cards-demo-container">
-        <DemoTableServerSideTable />
-    </div>
-</template>
-
-<template #code>
-
+:::code DemoTableServerSideTable
 <<< @/demos/table/DemoTableServerSideTable.vue
+:::
 
-</template>
-
-</Demo>
+::::

--- a/packages/documentation/docs/guide/components/textarea.md
+++ b/packages/documentation/docs/guide/components/textarea.md
@@ -1,69 +1,45 @@
 # Textarea
 
 <!-- 👉 Basic -->
-<Demo>
-
-## Basic
+::::card Basic
 
 You can use `ATextarea` component to render basic textarea.
 
-<DemoTextareaBasic />
-
-<template #code>
-
+:::code DemoTextareaBasic
 <<< @/demos/textarea/DemoTextareaBasic.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Placeholder -->
-<Demo>
-
-## Placeholder
+::::card Placeholder
 
 You can use `placeholder` attribute to add placeholder to the textarea.
 
-<DemoTextareaPlaceholder />
-
-<template #code>
-
+:::code DemoTextareaPlaceholder
 <<< @/demos/textarea/DemoTextareaPlaceholder.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Label -->
-<Demo>
-
-## Label
+::::card Label
 
 You can use `label` prop to add label to the textarea.
 
-<DemoTextareaLabel />
-
-<template #code>
-
+:::code DemoTextareaLabel
 <<< @/demos/textarea/DemoTextareaLabel.vue
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Height -->
-<Demo>
-
-## Height
+::::card Height
 
 You can adjust the height of ATextarea component by providing `height` prop with the value of valid height class.
 
-<DemoTextareaHeight />
-
-<template #code>
-
+:::code DemoTextareaHeight
 <<< @/demos/textarea/DemoTextareaHeight.vue
+:::
 
-</template>
-
-</Demo>
+::::

--- a/packages/documentation/docs/guide/composables/useGroupModel.md
+++ b/packages/documentation/docs/guide/composables/useGroupModel.md
@@ -1,54 +1,36 @@
 # useGroupModel
 
 <!-- 👉 Basic -->
-<Demo>
-
-## Basic
+::::card Basic
 
 `useGroupModel` allows you to create `v-model` like binding for a group.
 
 You can use `multi` property to enable selecting multiple values from options.
 
-<DemoUseGroupModelBasic />
-
-<template #code>
-
+:::code DemoUseGroupModelBasic
 <<< @/demos/composables/useGroupModel/DemoUseGroupModelBasic.vue{6-9}
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Indexed -->
-<Demo>
-
-## Indexed
+::::card Indexed
 
 You can also create options without predefined value. Pass any positive number to `options` property and it will create index based options.
 
-<DemoUseGroupModelIndexed />
-
-<template #code>
-
+:::code DemoUseGroupModelIndexed
 <<< @/demos/composables/useGroupModel/DemoUseGroupModelIndexed.vue{4}
+:::
 
-</template>
-
-</Demo>
+::::
 
 <!-- 👉 Object -->
-<Demo>
-
-## Object
+::::card Object
 
 description
 
-<DemoUseGroupModelObject />
-
-<template #code>
-
+:::code DemoUseGroupModelObject
 <<< @/demos/composables/useGroupModel/DemoUseGroupModelObject.vue{4-11}
+:::
 
-</template>
-
-</Demo>
+::::


### PR DESCRIPTION
Based on the issue #17 I updated all demos to use the new way of rendering demo cards.
@jd-solanki Could you please check if I have understood and implemented this correctly? 