### PR TITLE
docs: fix variant of ABtn in useGroupModel

### DIFF
--- a/packages/documentation/docs/demos/composables/useGroupModel/DemoUseGroupModelBasic.vue
+++ b/packages/documentation/docs/demos/composables/useGroupModel/DemoUseGroupModelBasic.vue
@@ -14,7 +14,7 @@ const { options, select, value } = useGroupModel<string>({
     <div class="flex flex-wrap gap-6 mb-4">
       <ABtn
         v-for="option in options"
-        :key="option.value"
+        :key="option.value + option.isSelected"
         :variant="option.isSelected ? 'fill' : 'light'"
         @click="select(option.value)"
       >

--- a/packages/documentation/docs/demos/composables/useGroupModel/DemoUseGroupModelIndexed.vue
+++ b/packages/documentation/docs/demos/composables/useGroupModel/DemoUseGroupModelIndexed.vue
@@ -9,7 +9,7 @@ const { options, select, value } = useGroupModel({
   <div class="flex flex-wrap gap-8 mb-4">
     <ABtn
       v-for="option in options"
-      :key="option.value"
+      :key="option.value.toString() + option.isSelected"
       :variant="option.isSelected ? 'fill' : 'light'"
       @click="select(option.value)"
     >


### PR DESCRIPTION
Hi!
In the page [useGroupModel](https://anu-vue.netlify.app/guide/composables/usegroupmodel.html), the `variant` of the buttons doesn't change.
This pull request fix this, but it's a little bit tricky...