### PR TITLE
docs: Highlight the lines related to the particular demos

### DIFF
--- a/packages/documentation/docs/demos/avatar/DemoAvatarDefault.vue
+++ b/packages/documentation/docs/demos/avatar/DemoAvatarDefault.vue
@@ -1,14 +1,20 @@
 <template>
   <div class="flex flex-wrap gap-4">
+    <!-- Content prop -->
     <AAvatar content="A" />
-    <AAvatar
-      color="success"
-      content="JD"
-    />
+
+    <!-- Default slot -->
+    <AAvatar color="success">
+      JD
+    </AAvatar>
+
+    <!-- icon -->
     <AAvatar
       color="info"
       icon="i-bx-support"
     />
+
+    <!-- Image -->
     <AAvatar src="/images/demo/portrait-1.jpg" />
   </div>
 </template>

--- a/packages/documentation/docs/demos/avatar/DemoAvatarFill.vue
+++ b/packages/documentation/docs/demos/avatar/DemoAvatarFill.vue
@@ -4,16 +4,19 @@
       variant="fill"
       content="A"
     />
+
     <AAvatar
       variant="fill"
       color="success"
       content="JD"
     />
+
     <AAvatar
       variant="fill"
       color="info"
       icon="i-bx-support"
     />
+
     <AAvatar src="/images/demo/portrait-1.jpg" />
   </div>
 </template>

--- a/packages/documentation/docs/demos/avatar/DemoAvatarOutlined.vue
+++ b/packages/documentation/docs/demos/avatar/DemoAvatarOutlined.vue
@@ -4,16 +4,19 @@
       variant="outline"
       content="A"
     />
+
     <AAvatar
       variant="outline"
       color="success"
       content="JD"
     />
+
     <AAvatar
       variant="outline"
       color="info"
       icon="i-bx-support"
     />
+
     <AAvatar src="/images/demo/portrait-1.jpg" />
   </div>
 </template>

--- a/packages/documentation/docs/guide/base-components/typography.md
+++ b/packages/documentation/docs/guide/base-components/typography.md
@@ -23,7 +23,7 @@ Want to create a list with title and subtitle no worries, Just add `text-sm`.
 You can use other font-size utilities to change typography size.
 
 :::code DemoTypographySizing
-<<< @/demos/typography/DemoTypographySizing.vue
+<<< @/demos/typography/DemoTypographySizing.vue{7,12,16,23,28,32,39,44,48}
 :::
 
 ::::
@@ -38,7 +38,7 @@ First element of array will be treated as content and rest of them will be class
 It greatly improves DX and keep you code a bit DRY.
 
 :::code DemoTypographyConfigArray
-<<< @/demos/typography/DemoTypographyConfigArray.vue
+<<< @/demos/typography/DemoTypographyConfigArray.vue{12-13,25-26,39-40,53-54}
 :::
 
 ::::

--- a/packages/documentation/docs/guide/components/alert.md
+++ b/packages/documentation/docs/guide/components/alert.md
@@ -5,6 +5,8 @@
 
 `light` is default variant for alert.
 
+Use `color` prop to change the alert color.
+
 :::code DemoAlertLight
 <<< @/demos/alert/DemoAlertLight.vue{7,11,15,19}
 :::

--- a/packages/documentation/docs/guide/components/alert.md
+++ b/packages/documentation/docs/guide/components/alert.md
@@ -6,7 +6,7 @@
 `light` is default variant for alert.
 
 :::code DemoAlertLight
-<<< @/demos/alert/DemoAlertLight.vue
+<<< @/demos/alert/DemoAlertLight.vue{7,11,15,19}
 :::
 
 ::::
@@ -17,7 +17,7 @@
 You can use `variant="fill"` to create alert with filled background.
 
 :::code DemoAlertFilled
-<<< @/demos/alert/DemoAlertFilled.vue
+<<< @/demos/alert/DemoAlertFilled.vue{3,8,15,22,29}
 :::
 
 ::::
@@ -28,7 +28,7 @@ You can use `variant="fill"` to create alert with filled background.
 You can use `variant="outline"` to create outlined alert.
 
 :::code DemoAlertOutlined
-<<< @/demos/alert/DemoAlertOutlined.vue
+<<< @/demos/alert/DemoAlertOutlined.vue{3,9,16,23,30}
 :::
 
 ::::
@@ -41,7 +41,7 @@ You can use `icon` prop to render icon in button.
 Use `append-icon` prop to render icon after default slot.
 
 :::code DemoAlertIcons
-<<< @/demos/alert/DemoAlertIcons.vue
+<<< @/demos/alert/DemoAlertIcons.vue{3,10,18}
 :::
 
 ::::
@@ -54,7 +54,7 @@ Use `dismissible` prop to create dismissible alert.
 You can customize close icon using `append-icon` prop.
 
 :::code DemoAlertDismissible
-<<< @/demos/alert/DemoAlertDismissible.vue
+<<< @/demos/alert/DemoAlertDismissible.vue{3,8,16}
 :::
 
 ::::
@@ -65,7 +65,7 @@ You can customize close icon using `append-icon` prop.
 Alert also support `v-model` to show and hide alert based on model value.
 
 :::code DemoAlertVModelSupport
-<<< @/demos/alert/DemoAlertVModelSupport.vue
+<<< @/demos/alert/DemoAlertVModelSupport.vue{4,9}
 :::
 
 ::::

--- a/packages/documentation/docs/guide/components/avatar.md
+++ b/packages/documentation/docs/guide/components/avatar.md
@@ -3,7 +3,9 @@
 <!-- 👉 Default -->
 ::::card Default
 
-Default variant for avatar is `light`
+Default variant for avatar is `light`.
+
+Use `color` prop to change the avatar color.
 
 :::code DemoAvatarDefault
 <<< @/demos/avatar/DemoAvatarDefault.vue
@@ -17,7 +19,7 @@ Default variant for avatar is `light`
 You can use `variant="fill"` to create avatar with filled background
 
 :::code DemoAvatarFill
-<<< @/demos/avatar/DemoAvatarFill.vue{4,8,13}
+<<< @/demos/avatar/DemoAvatarFill.vue{4,9,15}
 
 ::::
 
@@ -27,7 +29,7 @@ You can use `variant="fill"` to create avatar with filled background
 You can use variant="outline" to create outlined avatar
 
 :::code DemoAvatarOutlined
-<<< @/demos/avatar/DemoAvatarOutlined.vue{4,8,13}
+<<< @/demos/avatar/DemoAvatarOutlined.vue{4,9,15}
 :::
 
 ::::

--- a/packages/documentation/docs/guide/components/avatar.md
+++ b/packages/documentation/docs/guide/components/avatar.md
@@ -17,7 +17,7 @@ Default variant for avatar is `light`
 You can use `variant="fill"` to create avatar with filled background
 
 :::code DemoAvatarFill
-<<< @/demos/avatar/DemoAvatarFill.vue
+<<< @/demos/avatar/DemoAvatarFill.vue{4,8,13}
 
 ::::
 
@@ -27,7 +27,7 @@ You can use `variant="fill"` to create avatar with filled background
 You can use variant="outline" to create outlined avatar
 
 :::code DemoAvatarOutlined
-<<< @/demos/avatar/DemoAvatarOutlined.vue
+<<< @/demos/avatar/DemoAvatarOutlined.vue{4,8,13}
 :::
 
 ::::
@@ -38,7 +38,7 @@ You can use variant="outline" to create outlined avatar
 You can use font-size utility to adjust the size of avatar
 
 :::code DemoAvatarSizing
-<<< @/demos/avatar/DemoAvatarSizing.vue
+<<< @/demos/avatar/DemoAvatarSizing.vue{5,9,13,17,21}
 :::
 
 ::::
@@ -49,7 +49,7 @@ You can use font-size utility to adjust the size of avatar
 You can adjust avatar roundness using border-radius utilities
 
 :::code DemoAvatarRoundness
-<<< @/demos/avatar/DemoAvatarRoundness.vue
+<<< @/demos/avatar/DemoAvatarRoundness.vue{5,9,13,17,21}
 :::
 
 ::::

--- a/packages/documentation/docs/guide/components/button.md
+++ b/packages/documentation/docs/guide/components/button.md
@@ -17,7 +17,7 @@
 You can use `variant="outline"` to create outlined button.
 
 :::code DemoButtonOutlined
-<<< @/demos/button/DemoButtonOutlined.vue
+<<< @/demos/button/DemoButtonOutlined.vue{3,9,16,23,30}
 :::
 
 ::::
@@ -34,7 +34,7 @@ e.g. To create outline button with dashed border, add `border-dashed` class.
 You can use `variant="light"` to create button with light background _(Background with opacity)_.
 
 :::code DemoButtonLight
-<<< @/demos/button/DemoButtonLight.vue
+<<< @/demos/button/DemoButtonLight.vue{3,9,16,23,30}
 :::
 
 ::::
@@ -45,7 +45,7 @@ You can use `variant="light"` to create button with light background _(Backgroun
 Use `variant="text"` to create a text button.
 
 :::code DemoButtonText
-<<< @/demos/button/DemoButtonText.vue
+<<< @/demos/button/DemoButtonText.vue{3,8,15,22,29}
 :::
 
 ::::
@@ -58,13 +58,13 @@ You can use `icon` prop to render icon in button.
 Use `append-icon` prop to render icon after default slot.
 
 :::code DemoButtonIcons
-<<< @/demos/button/DemoButtonIcons.vue
+<<< @/demos/button/DemoButtonIcons.vue{4,10,17,23,33,41,49,57,67,75,83,91}
 :::
 
 ::::
 :::details You can also use default slot to render icon.
 
-```vue
+```vue{3}
 <template>
   <ABtn>
     <i class="i-bx-star" />
@@ -81,7 +81,7 @@ Use `append-icon` prop to render icon after default slot.
 Add `w-full` class to make block button.
 
 :::code DemoButtonBlock
-<<< @/demos/button/DemoButtonBlock.vue
+<<< @/demos/button/DemoButtonBlock.vue{3,7}
 :::
 
 ::::
@@ -92,7 +92,7 @@ Add `w-full` class to make block button.
 Use `icon-only` prop to render icon with icon only button.
 
 :::code DemoButtonIconOnly
-<<< @/demos/button/DemoButtonIconOnly.vue
+<<< @/demos/button/DemoButtonIconOnly.vue{4,10,16,22}
 :::
 
 ::::
@@ -103,7 +103,7 @@ Use `icon-only` prop to render icon with icon only button.
 You can use font-size utility to adjust the size of button.
 
 :::code DemoButtonSizing
-<<< @/demos/button/DemoButtonSizing.vue
+<<< @/demos/button/DemoButtonSizing.vue{4,12,17}
 :::
 
 ::::
@@ -118,7 +118,7 @@ If you have container with bigger font size and need default sized button use `t
 You can adjust button roundness using border-radius utilities.
 
 :::code DemoButtonRoundness
-<<< @/demos/button/DemoButtonRoundness.vue
+<<< @/demos/button/DemoButtonRoundness.vue{3,9,16,23,30}
 :::
 
 ::::

--- a/packages/documentation/docs/guide/components/button.md
+++ b/packages/documentation/docs/guide/components/button.md
@@ -5,8 +5,10 @@
 
 `fill` is default variant for button.
 
+Use `color` prop to change the button color.
+
 :::code DemoButtonFilled
-<<< @/demos/button/DemoButtonFilled.vue
+<<< @/demos/button/DemoButtonFilled.vue{5,9,13,17}
 :::
 
 ::::

--- a/packages/documentation/docs/guide/components/card.md
+++ b/packages/documentation/docs/guide/components/card.md
@@ -10,7 +10,7 @@ Moreover, you can also use `.card-body` in default slot to render card content.
 You can use `.card-spacer` helper class to add margin bottom to each of its children except last.
 
 :::code DemoCardBasic
-<<< @/demos/card/DemoCardBasic.vue
+<<< @/demos/card/DemoCardBasic.vue{12}
 :::
 
 ::::
@@ -36,7 +36,7 @@ Mix and match the different components to achieve desired UI.
 Card component uses layer composable as it's base. You can use `variant` prop to create various card variants.
 
 :::code DemoCardVariants
-<<< @/demos/card/DemoCardVariants.vue
+<<< @/demos/card/DemoCardVariants.vue{8,17,27,37}
 :::
 
 ::::
@@ -47,7 +47,7 @@ Card component uses layer composable as it's base. You can use `variant` prop to
 You can use `ATypography` slots to render custom content in header.
 
 :::code DemoCardSlot
-<<< @/demos/card/DemoCardSlot.vue
+<<< @/demos/card/DemoCardSlot.vue{8-17,25-34}
 :::
 
 ::::

--- a/packages/documentation/docs/guide/components/card.md
+++ b/packages/documentation/docs/guide/components/card.md
@@ -10,7 +10,7 @@ Moreover, you can also use `.card-body` in default slot to render card content.
 You can use `.card-spacer` helper class to add margin bottom to each of its children except last.
 
 :::code DemoCardBasic
-<<< @/demos/card/DemoCardBasic.vue{12}
+<<< @/demos/card/DemoCardBasic.vue
 :::
 
 ::::

--- a/packages/documentation/docs/guide/components/checkbox.md
+++ b/packages/documentation/docs/guide/components/checkbox.md
@@ -4,7 +4,7 @@
 ::::card Basic
 
 :::code DemoCheckboxBasic
-<<< @/demos/checkbox/DemoCheckboxBasic.vue
+<<< @/demos/checkbox/DemoCheckboxBasic.vue{4,9-11}
 :::
 
 ::::
@@ -15,7 +15,7 @@
 Use `icon` prop to change the checked icon.
 
 :::code DemoCheckboxIcon
-<<< @/demos/checkbox/DemoCheckboxIcon.vue
+<<< @/demos/checkbox/DemoCheckboxIcon.vue{3,7}
 :::
 
 ::::
@@ -26,7 +26,7 @@ Use `icon` prop to change the checked icon.
 `ACheckbox` also support arrays like a native checkbox.
 
 :::code DemoCheckboxArray
-<<< @/demos/checkbox/DemoCheckboxArray.vue
+<<< @/demos/checkbox/DemoCheckboxArray.vue{4,10,16,22,28}
 :::
 
 ::::
@@ -37,7 +37,7 @@ Use `icon` prop to change the checked icon.
 You can use `color` prop to change the checkbox color.
 
 :::code DemoCheckboxColor
-<<< @/demos/checkbox/DemoCheckboxColor.vue
+<<< @/demos/checkbox/DemoCheckboxColor.vue{4,11,18,25,32}
 :::
 
 ::::

--- a/packages/documentation/docs/guide/components/dialog.md
+++ b/packages/documentation/docs/guide/components/dialog.md
@@ -8,7 +8,7 @@
 All props & slots available in `ACard` is available in `ADialog`.
 
 :::code DemoDialogBasic
-<<< @/demos/dialog/DemoDialogBasic.vue
+<<< @/demos/dialog/DemoDialogBasic.vue{4,8-13}
 :::
 
 ::::
@@ -32,7 +32,7 @@ You can adjust dialog placement via `place-items-start top-16 justify-center` cl
 Use width utility classes to provide custom width to dialog. e.g. `w-[800px]`.
 
 :::code DemoDialogWidth
-<<< @/demos/dialog/DemoDialogWidth.vue
+<<< @/demos/dialog/DemoDialogWidth.vue{13}
 :::
 
 ::::
@@ -43,7 +43,7 @@ Use width utility classes to provide custom width to dialog. e.g. `w-[800px]`.
 You can disable closing dialog on outside click via `persistent` prop.
 
 :::code DemoDialogPersistent
-<<< @/demos/dialog/DemoDialogPersistent.vue
+<<< @/demos/dialog/DemoDialogPersistent.vue{13}
 :::
 
 ::::

--- a/packages/documentation/docs/guide/components/dialog.md
+++ b/packages/documentation/docs/guide/components/dialog.md
@@ -8,7 +8,7 @@
 All props & slots available in `ACard` is available in `ADialog`.
 
 :::code DemoDialogBasic
-<<< @/demos/dialog/DemoDialogBasic.vue{4,8-13}
+<<< @/demos/dialog/DemoDialogBasic.vue
 :::
 
 ::::

--- a/packages/documentation/docs/guide/components/input.md
+++ b/packages/documentation/docs/guide/components/input.md
@@ -30,7 +30,7 @@ You can use `label` prop to add label to the input.
 For maximum flexibility you can use `label` slot.
 
 :::code DemoInputLabel
-<<< @/demos/input/DemoInputLabel.vue{11,16}
+<<< @/demos/input/DemoInputLabel.vue{4,15-20}
 :::
 
 ::::
@@ -110,7 +110,7 @@ You can use `readonly` prop to make input read only.
 Use `disabled` prop to make input disabled.
 
 :::code DemoInputStates
-<<< @/demos/input/DemoInputStates.vue{11,16}
+<<< @/demos/input/DemoInputStates.vue{10,15}
 :::
 
 ::::

--- a/packages/documentation/docs/guide/components/input.md
+++ b/packages/documentation/docs/guide/components/input.md
@@ -6,7 +6,7 @@
 You can use `AInput` component to render basic input.
 
 :::code DemoInputBasic
-<<< @/demos/input/DemoInputBasic.vue
+<<< @/demos/input/DemoInputBasic.vue{4}
 :::
 
 ::::
@@ -17,7 +17,7 @@ You can use `AInput` component to render basic input.
 You can use `placeholder` attribute to add placeholder to the input.
 
 :::code DemoInputPlaceholder
-<<< @/demos/input/DemoInputPlaceholder.vue
+<<< @/demos/input/DemoInputPlaceholder.vue{6}
 :::
 
 ::::
@@ -45,7 +45,7 @@ When you use **label slot**, Note that label's `for` attribute needs to prefix t
 You can use `hint` prop to add hint to the input.
 
 :::code DemoInputHint
-<<< @/demos/input/DemoInputHint.vue
+<<< @/demos/input/DemoInputHint.vue{7}
 :::
 
 ::::
@@ -56,7 +56,7 @@ You can use `hint` prop to add hint to the input.
 You can use various icon location prop to add icon to the input.
 
 :::code DemoInputIcons
-<<< @/demos/input/DemoInputIcons.vue
+<<< @/demos/input/DemoInputIcons.vue{7,14,22,29}
 :::
 
 ::::
@@ -67,7 +67,7 @@ You can use various icon location prop to add icon to the input.
 You can use font-size utility to adjust the size of input.
 
 :::code DemoInputSizing
-<<< @/demos/input/DemoInputSizing.vue
+<<< @/demos/input/DemoInputSizing.vue{5,11,17,23,29}
 :::
 
 ::::
@@ -82,7 +82,7 @@ Like `AInput`, `ASelect` & `ATextarea` also built on top of `ABaseInput` base co
 You can adjust input roundness by providing border-radius utilities to `input-wrapper-classes` prop.
 
 :::code DemoInputRoundness
-<<< @/demos/input/DemoInputRoundness.vue
+<<< @/demos/input/DemoInputRoundness.vue{5,11,20,26}
 :::
 
 ::::
@@ -97,7 +97,7 @@ Like `AInput`, `ASelect` & `ATextarea` also built on top of `ABaseInput` base co
 You can use `type` attribute to add input type.
 
 :::code DemoInputTypes
-<<< @/demos/input/DemoInputTypes.vue
+<<< @/demos/input/DemoInputTypes.vue{4,8,12,16,20,24,28,32}
 :::
 
 ::::
@@ -110,7 +110,7 @@ You can use `readonly` prop to make input read only.
 Use `disabled` prop to make input disabled.
 
 :::code DemoInputStates
-<<< @/demos/input/DemoInputStates.vue
+<<< @/demos/input/DemoInputStates.vue{11,16}
 :::
 
 ::::
@@ -121,7 +121,7 @@ Use `disabled` prop to make input disabled.
 Anu do not provide any validation mechanism at the moment as it assume it's better handled by third-party libraries like [VeeValidate](https://vee-validate.logaretm.com/)
 
 :::code DemoInputValidation
-<<< @/demos/input/DemoInputValidation.vue
+<<< @/demos/input/DemoInputValidation.vue{2,6,13-14}
 :::
 
 ::::

--- a/packages/documentation/docs/guide/components/radio.md
+++ b/packages/documentation/docs/guide/components/radio.md
@@ -6,7 +6,7 @@
 Use `label` prop to set the label.
 
 :::code DemoRadioBasic
-<<< @/demos/radio/DemoRadioBasic.vue
+<<< @/demos/radio/DemoRadioBasic.vue{4,10,16,22,28}
 :::
 
 ::::
@@ -17,7 +17,7 @@ Use `label` prop to set the label.
 Use `color` prop to change the radio color.
 
 :::code DemoRadioColor
-<<< @/demos/radio/DemoRadioColor.vue
+<<< @/demos/radio/DemoRadioColor.vue{15}
 :::
 
 ::::

--- a/packages/documentation/docs/guide/components/select.md
+++ b/packages/documentation/docs/guide/components/select.md
@@ -6,7 +6,7 @@
 You can use `ASelect` component to render basic select.
 
 :::code DemoSelectBasic
-<<< @/demos/select/DemoSelectBasic.vue
+<<< @/demos/select/DemoSelectBasic.vue{5-6,9-16,22-26,29-33}
 :::
 
 ::::
@@ -17,7 +17,7 @@ You can use `ASelect` component to render basic select.
 You can use `placeholder` attribute to add placeholder to the select.
 
 :::code DemoSelectPlaceholder
-<<< @/demos/select/DemoSelectPlaceholder.vue
+<<< @/demos/select/DemoSelectPlaceholder.vue{13}
 :::
 
 ::::
@@ -28,7 +28,7 @@ You can use `placeholder` attribute to add placeholder to the select.
 You can use `label` prop to add label to the select.
 
 :::code DemoSelectLabel
-<<< @/demos/select/DemoSelectLabel.vue
+<<< @/demos/select/DemoSelectLabel.vue{13}
 :::
 
 ::::
@@ -39,7 +39,7 @@ You can use `label` prop to add label to the select.
 You can use `hint` prop to add hint to the select.
 
 :::code DemoSelectHint
-<<< @/demos/select/DemoSelectHint.vue
+<<< @/demos/select/DemoSelectHint.vue{13}
 :::
 
 ::::
@@ -54,7 +54,7 @@ To prepend the icon use `prepend-inner-icon` prop.
 Moreover, you can also use `append-icon` & `prepend-icon` prop to add icon outside of the select component.
 
 :::code DemoSelectIcons
-<<< @/demos/select/DemoSelectIcons.vue
+<<< @/demos/select/DemoSelectIcons.vue{12,17}
 :::
 
 ::::
@@ -65,7 +65,7 @@ Moreover, you can also use `append-icon` & `prepend-icon` prop to add icon outsi
 You can use default slot to render the `ASelect` options. Don't forget to bind `attrs` from [slotProps](https://vuejs.org/guide/components/slots.html#scoped-slots) to looping element.
 
 :::code DemoSelectSlot
-<<< @/demos/select/DemoSelectSlot.vue
+<<< @/demos/select/DemoSelectSlot.vue{18,21-30}
 :::
 
 ::::
@@ -78,7 +78,7 @@ You can use `readonly` prop to make select read only.
 Use `disabled` prop to make select disabled.
 
 :::code DemoSelectStates
-<<< @/demos/select/DemoSelectStates.vue
+<<< @/demos/select/DemoSelectStates.vue{12,18}
 :::
 
 ::::

--- a/packages/documentation/docs/guide/components/select.md
+++ b/packages/documentation/docs/guide/components/select.md
@@ -6,7 +6,7 @@
 You can use `ASelect` component to render basic select.
 
 :::code DemoSelectBasic
-<<< @/demos/select/DemoSelectBasic.vue{5-6,9-16,22-26,29-33}
+<<< @/demos/select/DemoSelectBasic.vue
 :::
 
 ::::

--- a/packages/documentation/docs/guide/components/switch.md
+++ b/packages/documentation/docs/guide/components/switch.md
@@ -6,7 +6,7 @@
 Use `ASwitch` component to create toggle for boolean value.
 
 :::code DemoSwitchBasic
-<<< @/demos/switch/DemoSwitchBasic.vue
+<<< @/demos/switch/DemoSwitchBasic.vue{4,8}
 :::
 
 ::::
@@ -17,7 +17,7 @@ Use `ASwitch` component to create toggle for boolean value.
 You can use `color` prop to change the switch color
 
 :::code DemoSwitchColors
-<<< @/demos/switch/DemoSwitchColors.vue
+<<< @/demos/switch/DemoSwitchColors.vue{15,19,23,27,31}
 :::
 
 ::::
@@ -32,7 +32,7 @@ Label and switch have `justify-between` added as this is how generally used but 
 <br>
 
 :::code DemoSwitchLabel
-<<< @/demos/switch/DemoSwitchLabel.vue
+<<< @/demos/switch/DemoSwitchLabel.vue{13,17,21}
 :::
 
 ::::
@@ -47,7 +47,7 @@ You can also use default slot to render the label
 Use `on-icon` & `off-icon` prop to render icons inside switch dot.
 
 :::code DemoSwitchIcons
-<<< @/demos/switch/DemoSwitchIcons.vue
+<<< @/demos/switch/DemoSwitchIcons.vue{15-16,20-21,26-27,32-33,38-39}
 :::
 
 ::::
@@ -58,7 +58,7 @@ Use `on-icon` & `off-icon` prop to render icons inside switch dot.
 You can use font-size utility to adjust the size of switch
 
 :::code DemoSwitchSizing
-<<< @/demos/switch/DemoSwitchSizing.vue
+<<< @/demos/switch/DemoSwitchSizing.vue{16,20,25,29,33}
 :::
 
 ::::
@@ -69,7 +69,7 @@ You can use font-size utility to adjust the size of switch
 You can use `disabled` prop to disable the switch
 
 :::code DemoSwitchStates
-<<< @/demos/switch/DemoSwitchStates.vue
+<<< @/demos/switch/DemoSwitchStates.vue{23,28}
 :::
 
 ::::
@@ -80,7 +80,7 @@ You can use `disabled` prop to disable the switch
 You can adjust switch roundness using border-radius utilities
 
 :::code DemoSwitchRoundness
-<<< @/demos/switch/DemoSwitchRoundness.vue
+<<< @/demos/switch/DemoSwitchRoundness.vue{12,16}
 :::
 
 ::::

--- a/packages/documentation/docs/guide/components/table.md
+++ b/packages/documentation/docs/guide/components/table.md
@@ -6,7 +6,7 @@
 Use `rows` prop to provide data to `ATable`. Defining columns for table is optional. When columns aren't specified, columns will get calculate from first row and all columns will be filterable and sortable.
 
 :::code DemoTableBasic
-<<< @/demos/table/DemoTableBasic.vue{2-28,33}
+<<< @/demos/table/DemoTableBasic.vue{33}
 :::
 
 ::::
@@ -80,7 +80,7 @@ Define extra column in column definition to add column to table. Later, you can 
 Moreover, you can also omit the column definition to omit rendering the specific column.
 
 :::code DemoTableExtraColumn
-<<< @/demos/table/DemoTableExtraColumn.vue{43-67}
+<<< @/demos/table/DemoTableExtraColumn.vue{33,43-67}
 :::
 
 ::::

--- a/packages/documentation/docs/guide/components/table.md
+++ b/packages/documentation/docs/guide/components/table.md
@@ -6,7 +6,7 @@
 Use `rows` prop to provide data to `ATable`. Defining columns for table is optional. When columns aren't specified, columns will get calculate from first row and all columns will be filterable and sortable.
 
 :::code DemoTableBasic
-<<< @/demos/table/DemoTableBasic.vue
+<<< @/demos/table/DemoTableBasic.vue{2-28,33}
 :::
 
 ::::
@@ -17,7 +17,7 @@ Use `rows` prop to provide data to `ATable`. Defining columns for table is optio
 You can use `columns` prop to define columns for the table.
 
 :::code DemoTableColumnDefinition
-<<< @/demos/table/DemoTableColumnDefinition.vue
+<<< @/demos/table/DemoTableColumnDefinition.vue{30-34,41}
 :::
 
 ::::
@@ -28,7 +28,7 @@ You can use `columns` prop to define columns for the table.
 Use `formatter` property while defining column to format the column text.
 
 :::code DemoTableColumnFormatter
-<<< @/demos/table/DemoTableColumnFormatter.vue
+<<< @/demos/table/DemoTableColumnFormatter.vue{32}
 :::
 
 ::::
@@ -39,7 +39,7 @@ Use `formatter` property while defining column to format the column text.
 `ATable` generates scoped slot based on your column name. If your column name is `website` then you can use `row-website` scoped slot to render custom content in your column.
 
 :::code DemoTableColumnSlot
-<<< @/demos/table/DemoTableColumnSlot.vue
+<<< @/demos/table/DemoTableColumnSlot.vue{35-39,42-47}
 :::
 
 ::::
@@ -49,10 +49,10 @@ Use `formatter` property while defining column to format the column text.
 
 Set `search` prop to `true` to enable table filtering.
 
-Search will respect the column's `isFilterable` property to include or exclude the column from searching. If you don't specify column defination all columns will be filterable.
+Search will respect the column's `isFilterable` property to include or exclude the column from searching. If you don't specify column definition all columns will be filterable.
 
 :::code DemoTableFiltering
-<<< @/demos/table/DemoTableFiltering.vue
+<<< @/demos/table/DemoTableFiltering.vue{35}
 :::
 
 ::::
@@ -80,7 +80,7 @@ Define extra column in column definition to add column to table. Later, you can 
 Moreover, you can also omit the column definition to omit rendering the specific column.
 
 :::code DemoTableExtraColumn
-<<< @/demos/table/DemoTableExtraColumn.vue
+<<< @/demos/table/DemoTableExtraColumn.vue{43-67}
 :::
 
 ::::
@@ -111,7 +111,7 @@ const fetchRows = ({ q, currentPage, rowsPerPage, sortedCols }) => {
 ```
 
 :::code DemoTableServerSideTable
-<<< @/demos/table/DemoTableServerSideTable.vue
+<<< @/demos/table/DemoTableServerSideTable.vue{277-334,340}
 :::
 
 ::::

--- a/packages/documentation/docs/guide/components/textarea.md
+++ b/packages/documentation/docs/guide/components/textarea.md
@@ -6,7 +6,7 @@
 You can use `ATextarea` component to render basic textarea.
 
 :::code DemoTextareaBasic
-<<< @/demos/textarea/DemoTextareaBasic.vue{2}
+<<< @/demos/textarea/DemoTextareaBasic.vue
 :::
 
 ::::
@@ -17,7 +17,7 @@ You can use `ATextarea` component to render basic textarea.
 You can use `placeholder` attribute to add placeholder to the textarea.
 
 :::code DemoTextareaPlaceholder
-<<< @/demos/textarea/DemoTextareaPlaceholder.vue{2}
+<<< @/demos/textarea/DemoTextareaPlaceholder.vue
 :::
 
 ::::
@@ -28,7 +28,7 @@ You can use `placeholder` attribute to add placeholder to the textarea.
 You can use `label` prop to add label to the textarea.
 
 :::code DemoTextareaLabel
-<<< @/demos/textarea/DemoTextareaLabel.vue{2}
+<<< @/demos/textarea/DemoTextareaLabel.vue
 :::
 
 ::::
@@ -39,7 +39,7 @@ You can use `label` prop to add label to the textarea.
 You can adjust the height of ATextarea component by providing `height` prop with the value of valid height class.
 
 :::code DemoTextareaHeight
-<<< @/demos/textarea/DemoTextareaHeight.vue{2}
+<<< @/demos/textarea/DemoTextareaHeight.vue
 :::
 
 ::::

--- a/packages/documentation/docs/guide/components/textarea.md
+++ b/packages/documentation/docs/guide/components/textarea.md
@@ -6,7 +6,7 @@
 You can use `ATextarea` component to render basic textarea.
 
 :::code DemoTextareaBasic
-<<< @/demos/textarea/DemoTextareaBasic.vue
+<<< @/demos/textarea/DemoTextareaBasic.vue{2}
 :::
 
 ::::
@@ -17,7 +17,7 @@ You can use `ATextarea` component to render basic textarea.
 You can use `placeholder` attribute to add placeholder to the textarea.
 
 :::code DemoTextareaPlaceholder
-<<< @/demos/textarea/DemoTextareaPlaceholder.vue
+<<< @/demos/textarea/DemoTextareaPlaceholder.vue{2}
 :::
 
 ::::
@@ -28,7 +28,7 @@ You can use `placeholder` attribute to add placeholder to the textarea.
 You can use `label` prop to add label to the textarea.
 
 :::code DemoTextareaLabel
-<<< @/demos/textarea/DemoTextareaLabel.vue
+<<< @/demos/textarea/DemoTextareaLabel.vue{2}
 :::
 
 ::::
@@ -39,7 +39,7 @@ You can use `label` prop to add label to the textarea.
 You can adjust the height of ATextarea component by providing `height` prop with the value of valid height class.
 
 :::code DemoTextareaHeight
-<<< @/demos/textarea/DemoTextareaHeight.vue
+<<< @/demos/textarea/DemoTextareaHeight.vue{2}
 :::
 
 ::::


### PR DESCRIPTION
Based on issue #19, I have highlighted all lines related to a particular demo.

Note: I'm not sure if the highlighting is correct for `DemoCardBasic` and I also skipped `DemoCardVariousElements` and `DemoTableSorting`.