### PR TITLE
fix: set no-reduclare eslint warn

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -66,6 +66,7 @@ module.exports = {
     ],
 
     '@typescript-eslint/consistent-type-imports': 'error',
+    '@typescript-eslint/no-redeclare': 'warn',
   },
   settings: {
     'import/parsers': {


### PR DESCRIPTION
<img width="838" alt="image" src="https://user-images.githubusercontent.com/73536160/194686446-9bf559ce-44cb-49d7-a7bb-896218ca520f.png">

Should we separate type declaration?