### PR TITLE
docs(badge): fix content props name and highlight lines

### DIFF
--- a/packages/documentation/docs/guide/components/badge.md
+++ b/packages/documentation/docs/guide/components/badge.md
@@ -11,24 +11,24 @@ Default variant for badge is `standard`
 
 ::::
 
-<!-- 👉 Color -->
+<!-- 👉 Content -->
 ::::card Content
 
-Use the prop `badgeContent` to pass numeric values, if you want to use other data different than a number use the slot `badgeContent` instead
+Use the prop `content` to pass numeric values, if you want to use other data different than a number use the slot `content` instead
 
 :::code DemoBadgeContent
-<<< @/demos/badge/DemoBadgeContent.vue
+<<< @/demos/badge/DemoBadgeContent.vue{4,15,20}
 :::
 
 ::::
 
-<!-- 👉 Content -->
+<!-- 👉 Color -->
 ::::card Color
 
 You can use `color` prop to change the badge color.
 
 :::code DemoBadgeColor
-<<< @/demos/badge/DemoBadgeColor.vue
+<<< @/demos/badge/DemoBadgeColor.vue{5,11,17,23,29}
 :::
 
 ::::
@@ -39,7 +39,7 @@ You can use `color` prop to change the badge color.
 Use the prop `variant` to transform the badge into a `dot`
 
 :::code DemoBadgeDot
-<<< @/demos/badge/DemoBadgeDot.vue
+<<< @/demos/badge/DemoBadgeDot.vue{3}
 :::
 
 ::::
@@ -50,7 +50,7 @@ Use the prop `variant` to transform the badge into a `dot`
 Change the position of the badge by passing `horizontal` and `vertical` values to the `anchor` prop.
 
 :::code DemoBadgeAnchor
-<<< @/demos/badge/DemoBadgeAnchor.vue
+<<< @/demos/badge/DemoBadgeAnchor.vue{5,11,17,23}
 :::
 
 ::::
@@ -61,7 +61,7 @@ Change the position of the badge by passing `horizontal` and `vertical` values t
 Change the `max` prop to cap the numeric value of the content
 
 :::code DemoBadgeMax
-<<< @/demos/badge/DemoBadgeMax.vue
+<<< @/demos/badge/DemoBadgeMax.vue{5,11,17}
 :::
 
 ::::
@@ -74,7 +74,7 @@ Use `overlap` prop to adjust the position of the badge, if you need more refined
 By default of `overlap` prop is `true`.
 
 :::code DemoBadgeOverlap
-<<< @/demos/badge/DemoBadgeOverlap.vue
+<<< @/demos/badge/DemoBadgeOverlap.vue{10,18-19}
 :::
 
 ::::


### PR DESCRIPTION
- `content` prop and slot was misnamed.
- Comment section name was upside down.
- Added code lines highlight.