### PR TITLE
fix(typography): preserve typographyHeader reactivity

### DIFF
--- a/packages/anu-vue/src/components/list/AList.tsx
+++ b/packages/anu-vue/src/components/list/AList.tsx
@@ -6,12 +6,14 @@ import { useLayer, useProps as useLayerProps } from '@/composables/useLayer'
 
 import { AAvatar, isAvatarUsed } from '@/components/avatar'
 import type { AvatarOnlyProps } from '@/components/avatar/props'
+import type { ConfigurableValue } from '@/composables/useConfigurable'
+import { useConfigurable } from '@/composables/useConfigurable'
 
 // TODO: Reuse the existing props and its types. Maybe if we create AListItem component then we can reuse prop types.
 interface ListItem extends AvatarOnlyProps {
-  title: string | string[]
-  subtitle?: string | string[]
-  text: string | string[]
+  title: ConfigurableValue
+  subtitle?: ConfigurableValue
+  text: ConfigurableValue
   src?: string
   value?: any
   disable?: boolean
@@ -107,19 +109,11 @@ export const AList = defineComponent({
     // 👉 List items
     const listItems = computed(() => props.items.map((listItem, itemIndex) => {
       // ℹ️ Reduce the size of title to 1rem. We did the same in ACard as well.
-      let titleProp: string[] | undefined
-      if (listItem.title) {
-        // if title property is string
-        if (typeof listItem.title === 'string') {
-          titleProp = [listItem.title, 'text-base']
-        }
-
-        // title property is array
-        else {
-          const [textContent, textClasses] = listItem.title
-          titleProp = [textContent, `${textClasses} uno-layer-base-text-sm`]
-        }
-      }
+      const _titleProp = useConfigurable(listItem.title)
+      if (Array.isArray(_titleProp.value.classes))
+        _titleProp.value.classes = [..._titleProp.value.classes, 'uno-layer-base-text-base']
+      else
+        _titleProp.value.classes += ' uno-layer-base-text-base'
 
       const isActive = computed(() => options.value[itemIndex].isSelected)
 
@@ -149,7 +143,7 @@ export const AList = defineComponent({
                 ? avatarRenderer(listItem.content, listItem.src, listItem.alt, listItem.icon, listItem.$avatar)
                 : null
           }
-          <ATypography class="flex-grow" title={titleProp} subtitle={listItem.subtitle} text={listItem.text}></ATypography>
+          <ATypography class="flex-grow" title={Object.values(_titleProp.value) as ConfigurableValue} subtitle={listItem.subtitle} text={listItem.text}></ATypography>
           {
             slots.append
               ? slots.append({ listItem, itemIndex })

--- a/packages/anu-vue/src/components/typography/ATypography.tsx
+++ b/packages/anu-vue/src/components/typography/ATypography.tsx
@@ -1,6 +1,4 @@
-import type { Ref } from 'vue'
 import { defineComponent, toRef } from 'vue'
-import type { ConfigurableValue } from '@/composables/useConfigurable'
 import { useConfigurable } from '@/composables/useConfigurable'
 import { useTypographyProps } from '@/composables/useTypography'
 
@@ -10,13 +8,9 @@ export const ATypography = defineComponent({
     ...useTypographyProps(),
   },
   setup(props, { slots }) {
-    const typographyItems = ['title', 'subtitle', 'text'] as const
-
-    const data = typographyItems.reduce((acc, item) => {
-      acc[item] = useConfigurable(toRef(props, item) as Ref<ConfigurableValue>)
-
-      return acc
-    }, {} as Record<typeof typographyItems[number], ReturnType<typeof useConfigurable>>)
+    const title = useConfigurable(toRef(props, 'title'))
+    const subtitle = useConfigurable(toRef(props, 'subtitle'))
+    const text = useConfigurable(toRef(props, 'text'))
 
     // TODO: Remove class block and use commented tag defaults instead of span once VitePress allow style isolation
     return () => {
@@ -24,12 +18,12 @@ export const ATypography = defineComponent({
         <div class="flex-grow">
             {
                 slots.title || props.title
-                  ? <props.titleTag class={['font-medium block em:uno-layer-base-text-lg uno-layer-base-text-[hsla(var(--a-typography-title-color),var(--a-typography-title-opacity))]', data.title.value.classes]}>{slots.title ? slots.title() : data.title.value.content}</props.titleTag>
+                  ? <props.titleTag {...title.value.attrs} class={['font-medium block em:uno-layer-base-text-lg uno-layer-base-text-[hsla(var(--a-typography-title-color),var(--a-typography-title-opacity))]', title.value.classes]}>{slots.title ? slots.title() : title.value.content}</props.titleTag>
                   : null
             }
             {
                 slots.subtitle || props.subtitle
-                  ? <props.subtitleTag class={['block em:uno-layer-base-text-sm uno-layer-base-text-[hsla(var(--a-typography-subtitle-color),var(--a-typography-subtitle-opacity))]', data.subtitle.value.classes]}>{slots.subtitle ? slots.subtitle() : data.subtitle.value.content}</props.subtitleTag>
+                  ? <props.subtitleTag {...subtitle.value.attrs} class={['block em:uno-layer-base-text-sm uno-layer-base-text-[hsla(var(--a-typography-subtitle-color),var(--a-typography-subtitle-opacity))]', subtitle.value.classes]}>{slots.subtitle ? slots.subtitle() : subtitle.value.content}</props.subtitleTag>
                   : null
             }
         </div>
@@ -40,7 +34,7 @@ export const ATypography = defineComponent({
             {slots.title || props.title || slots.subtitle || props.subtitle || slots.headerRight ? typographyHeader : null}
             {
                 slots.default || props.text
-                  ? <props.textTag class={['em:uno-layer-base-text-base uno-layer-base-text-[hsla(var(--a-typography-text-color),var(--a-typography-text-opacity))]', data.text.value.classes]}>{slots.default ? slots.default() : data.text.value.content}</props.textTag>
+                  ? <props.textTag {...text.value.attrs} class={['em:uno-layer-base-text-base uno-layer-base-text-[hsla(var(--a-typography-text-color),var(--a-typography-text-opacity))]', text.value.classes]}>{slots.default ? slots.default() : text.value.content}</props.textTag>
                   : null
             }
         </div>

--- a/packages/anu-vue/src/components/typography/ATypography.tsx
+++ b/packages/anu-vue/src/components/typography/ATypography.tsx
@@ -47,7 +47,9 @@ export const ATypography = defineComponent({
       }
     })
 
-    const typographyHeader = <div class="flex justify-between">
+    // TODO: Remove class block and use commented tag defaults instead of span once VitePress allow style isolation
+    return () => {
+      const typographyHeader = <div class="flex justify-between">
         <div class="flex-grow">
             {
                 slots.title || props.title
@@ -63,8 +65,7 @@ export const ATypography = defineComponent({
         {slots.headerRight?.()}
     </div>
 
-    // TODO: Remove class block and use commented tag defaults instead of span once VitePress allow style isolation
-    return () => <div class="uno-layer-base-text-base gap-4 flex flex-col">
+      return <div class="uno-layer-base-text-base gap-4 flex flex-col">
             {slots.title || props.title || slots.subtitle || props.subtitle || slots.headerRight ? typographyHeader : null}
             {
                 slots.default || props.text
@@ -72,6 +73,7 @@ export const ATypography = defineComponent({
                   : null
             }
         </div>
+    }
   },
 })
 

--- a/packages/anu-vue/src/components/typography/ATypography.tsx
+++ b/packages/anu-vue/src/components/typography/ATypography.tsx
@@ -7,45 +7,26 @@ export const ATypography = defineComponent({
     ...useTypographyProps(),
   },
   setup(props, { slots }) {
-    const title = computed(() => {
-      const [titleContent, titleClasses] = props.title === undefined
+    const typographyItems = ['title', 'subtitle', 'text'] as const
+
+    const computeContentAndClasses = (item: typeof typographyItems[number]) => computed(() => {
+      const [content, classes] = props[item] === undefined
         ? []
-        : typeof props.title === 'string'
-          ? [props.title]
-          : props.title
+        : typeof props[item] === 'string'
+          ? [props[item]]
+          : props[item] as [string, string]
 
       return {
-        titleContent,
-        titleClasses,
+        content,
+        classes,
       }
     })
 
-    // const [subtitleContent, subtitleClasses] = computed(() => props.subtitle === undefined
-    const subtitle = computed(() => {
-      const [subtitleContent, subtitleClasses] = props.subtitle === undefined
-        ? []
-        : typeof props.subtitle === 'string'
-          ? [props.subtitle]
-          : props.subtitle
+    const data = typographyItems.reduce((acc, item) => {
+      acc[item] = computeContentAndClasses(item)
 
-      return {
-        subtitleContent,
-        subtitleClasses,
-      }
-    })
-
-    const text = computed(() => {
-      const [textContent, textClasses] = props.text === undefined
-        ? []
-        : typeof props.text === 'string'
-          ? [props.text]
-          : props.text
-
-      return {
-        textContent,
-        textClasses,
-      }
-    })
+      return acc
+    }, {} as Record<typeof typographyItems[number], ReturnType<typeof computeContentAndClasses>>)
 
     // TODO: Remove class block and use commented tag defaults instead of span once VitePress allow style isolation
     return () => {
@@ -53,12 +34,12 @@ export const ATypography = defineComponent({
         <div class="flex-grow">
             {
                 slots.title || props.title
-                  ? <props.titleTag class={['font-medium block em:uno-layer-base-text-lg uno-layer-base-text-[hsla(var(--a-typography-title-color),var(--a-typography-title-opacity))]', title.value.titleClasses]}>{slots.title ? slots.title() : title.value.titleContent}</props.titleTag>
+                  ? <props.titleTag class={['font-medium block em:uno-layer-base-text-lg uno-layer-base-text-[hsla(var(--a-typography-title-color),var(--a-typography-title-opacity))]', data.title.value.classes]}>{slots.title ? slots.title() : data.title.value.content}</props.titleTag>
                   : null
             }
             {
                 slots.subtitle || props.subtitle
-                  ? <props.subtitleTag class={['block em:uno-layer-base-text-sm uno-layer-base-text-[hsla(var(--a-typography-subtitle-color),var(--a-typography-subtitle-opacity))]', subtitle.value.subtitleClasses]}>{slots.subtitle ? slots.subtitle() : subtitle.value.subtitleContent}</props.subtitleTag>
+                  ? <props.subtitleTag class={['block em:uno-layer-base-text-sm uno-layer-base-text-[hsla(var(--a-typography-subtitle-color),var(--a-typography-subtitle-opacity))]', data.subtitle.value.classes]}>{slots.subtitle ? slots.subtitle() : data.subtitle.value.content}</props.subtitleTag>
                   : null
             }
         </div>
@@ -69,7 +50,7 @@ export const ATypography = defineComponent({
             {slots.title || props.title || slots.subtitle || props.subtitle || slots.headerRight ? typographyHeader : null}
             {
                 slots.default || props.text
-                  ? <props.textTag class={['em:uno-layer-base-text-base uno-layer-base-text-[hsla(var(--a-typography-text-color),var(--a-typography-text-opacity))]', text.value.textClasses]}>{slots.default ? slots.default() : text.value.textContent}</props.textTag>
+                  ? <props.textTag class={['em:uno-layer-base-text-base uno-layer-base-text-[hsla(var(--a-typography-text-color),var(--a-typography-text-opacity))]', data.text.value.classes]}>{slots.default ? slots.default() : data.text.value.content}</props.textTag>
                   : null
             }
         </div>

--- a/packages/anu-vue/src/components/typography/ATypography.tsx
+++ b/packages/anu-vue/src/components/typography/ATypography.tsx
@@ -1,4 +1,7 @@
-import { computed, defineComponent } from 'vue'
+import type { Ref } from 'vue'
+import { defineComponent, toRef } from 'vue'
+import type { ConfigurableValue } from '@/composables/useConfigurable'
+import { useConfigurable } from '@/composables/useConfigurable'
 import { useTypographyProps } from '@/composables/useTypography'
 
 export const ATypography = defineComponent({
@@ -9,24 +12,11 @@ export const ATypography = defineComponent({
   setup(props, { slots }) {
     const typographyItems = ['title', 'subtitle', 'text'] as const
 
-    const computeContentAndClasses = (item: typeof typographyItems[number]) => computed(() => {
-      const [content, classes] = props[item] === undefined
-        ? []
-        : typeof props[item] === 'string'
-          ? [props[item]]
-          : props[item] as [string, string]
-
-      return {
-        content,
-        classes,
-      }
-    })
-
     const data = typographyItems.reduce((acc, item) => {
-      acc[item] = computeContentAndClasses(item)
+      acc[item] = useConfigurable(toRef(props, item) as Ref<ConfigurableValue>)
 
       return acc
-    }, {} as Record<typeof typographyItems[number], ReturnType<typeof computeContentAndClasses>>)
+    }, {} as Record<typeof typographyItems[number], ReturnType<typeof useConfigurable>>)
 
     // TODO: Remove class block and use commented tag defaults instead of span once VitePress allow style isolation
     return () => {

--- a/packages/anu-vue/src/composables/useConfigurable.ts
+++ b/packages/anu-vue/src/composables/useConfigurable.ts
@@ -1,5 +1,6 @@
 import type { MaybeRef } from '@vueuse/core'
 import { resolveUnref } from '@vueuse/core'
+import { computed } from 'vue'
 
 // ℹ️ We might need generic here in future
 
@@ -9,7 +10,7 @@ export type ClassStyleAttr = ClassStyleType | ClassStyleType[]
 export type AttrsType = { string: any } | undefined
 export type ConfigurableValue = undefined | ContentType | [ContentType, ClassStyleAttr] | [ContentType, ClassStyleAttr, AttrsType]
 
-export const useConfigurable = (value: MaybeRef<ConfigurableValue>): { content: ContentType; classes: ClassStyleAttr; attrs: AttrsType } => {
+export const useConfigurable = (value: MaybeRef<ConfigurableValue>) => computed(() => {
   const _value = resolveUnref(value)
 
   const [content, classes, attrs] = _value === undefined
@@ -19,4 +20,4 @@ export const useConfigurable = (value: MaybeRef<ConfigurableValue>): { content: 
       : _value
 
   return { content, classes, attrs }
-}
+})

--- a/packages/anu-vue/src/composables/useConfigurable.ts
+++ b/packages/anu-vue/src/composables/useConfigurable.ts
@@ -5,10 +5,10 @@ import { computed } from 'vue'
 // ℹ️ We might need generic here in future
 
 export type ContentType = string | number | undefined
-export type ClassStyleType = string | { string: boolean } | undefined
-export type ClassStyleAttr = ClassStyleType | ClassStyleType[]
-export type AttrsType = { string: any } | undefined
-export type ConfigurableValue = undefined | ContentType | [ContentType, ClassStyleAttr] | [ContentType, ClassStyleAttr, AttrsType]
+export type Class = string | Record<string, boolean> | undefined
+export type ClassAttr = Class | Class[]
+export type AttrsType = Record<string, any> | undefined
+export type ConfigurableValue = undefined | ContentType | [ContentType, ClassAttr] | [ContentType, ClassAttr, AttrsType]
 
 export const useConfigurable = (value: MaybeRef<ConfigurableValue>) => computed(() => {
   const _value = resolveUnref(value)
@@ -20,4 +20,5 @@ export const useConfigurable = (value: MaybeRef<ConfigurableValue>) => computed(
       : _value
 
   return { content, classes, attrs }
-})
+},
+)

--- a/packages/anu-vue/src/composables/useTypography.ts
+++ b/packages/anu-vue/src/composables/useTypography.ts
@@ -1,4 +1,5 @@
 import type { ComponentObjectPropsOptions, PropType, Slots, ToRefs } from 'vue'
+import type { ConfigurableValue } from '@/composables/useConfigurable'
 
 export const useTypographyProps = (propOverrides?: Partial<ComponentObjectPropsOptions>) => {
   const props = {
@@ -6,17 +7,17 @@ export const useTypographyProps = (propOverrides?: Partial<ComponentObjectPropsO
     /**
      * Typography title
      */
-    title: [String, Array] as PropType<string | string[]>,
+    title: [String, Array] as PropType<ConfigurableValue>,
 
     /**
      * Typography subtitle
      */
-    subtitle: [String, Array] as PropType<string | string[]>,
+    subtitle: [String, Array] as PropType<ConfigurableValue>,
 
     /**
      * Typography text content
      */
-    text: [String, Array] as PropType<string | string[]>,
+    text: [String, Array] as PropType<ConfigurableValue>,
 
     /**
      * Tag to use for title of the card
@@ -54,7 +55,7 @@ export const useTypographyProps = (propOverrides?: Partial<ComponentObjectPropsO
   return props
 }
 
-// Thanks: https://masteringjs.io/tutorials/fundamentals/filter-object
+// Thanks: <https://masteringjs.io/tutorials/fundamentals/filter-object>
 // TODO(TS): improve typing so that it only returns the typography types. Omit using `Partial`
 export const extractTypographyProp = <T>(props: ToRefs<T>): Partial<ToRefs<T>> => {
   return Object.fromEntries(


### PR DESCRIPTION
Title and subtitle of `<ATypography />` are not reactive. 
### Expected behavior:
![Kapture 2022-10-19 at 19 56 30](https://user-images.githubusercontent.com/58697105/196769424-680e85fe-92e5-4192-a828-ba42a5304520.gif)
### Current behavior: 
![Kapture 2022-10-19 at 19 53 02](https://user-images.githubusercontent.com/58697105/196769239-19a6398f-34d3-46ed-a60b-0e0f70210890.gif)
