### PR TITLE
feat(ABtn): focus with themeColor

### DIFF
--- a/packages/anu-vue/src/components/btn/ABtn.tsx
+++ b/packages/anu-vue/src/components/btn/ABtn.tsx
@@ -63,7 +63,7 @@ export const ABtn = defineComponent({
     )
 
     // FIX: ABtn gets full width if placed inside flex container
-    return () => <button class={[props.iconOnly ? 'a-btn-icon-only' : 'a-btn', 'uno-layer-base-text-base whitespace-nowrap inline-flex justify-center items-center', { 'opacity-50 pointer-events-none': props.disabled }, ...classes.value]} style={[...styles.value]}>
+    return () => <button class={[props.iconOnly ? 'a-btn-icon-only' : 'a-btn', 'uno-layer-base-text-base whitespace-nowrap inline-flex justify-center items-center', { 'opacity-50 pointer-events-none': props.disabled }, ...classes.value]} style={[...styles.value]} tabindex={props.disabled ? -1 : 0}>
       {props.icon ? <i class={props.icon}></i> : null}{slots.default?.()}{props.appendIcon ? <i class={props.appendIcon}></i> : null}
     </button>
   },

--- a/packages/anu-vue/src/composables/useLayer.ts
+++ b/packages/anu-vue/src/composables/useLayer.ts
@@ -68,9 +68,9 @@ export const useLayer = () => {
       }
     }
 
-    // If it's theme color => Use color's CSS var to `--a-layer-color`
+    // If it's theme color => Use color's CSS var to `--a-layer-color` and to ring color '--un-ring-color'
     else {
-      styles.push({ '--a-layer-color': `hsla(var(--a-${propColor}),var(--un-bg-opacity))` })
+      styles.push({ '--a-layer-color': `hsla(var(--a-${propColor}),var(--un-bg-opacity))` }, { '--un-ring-color': `hsla(var(--a-${propColor}),var(--a-ring-opacity))` })
 
       // ℹ️ We need to set un-bg-opacity just like UnoCSS class
       classes.push('[--un-bg-opacity:1]')

--- a/packages/anu-vue/src/presets/theme-default/index.ts
+++ b/packages/anu-vue/src/presets/theme-default/index.ts
@@ -57,8 +57,8 @@ const themeShortcuts: Exclude<Preset['shortcuts'], undefined> = [
     'a-badge-bordered': 'outline outline-2 outline-[hsl(var(--a-layer))]',
 
     // 👉 Button
-    'a-btn': 'px-[1em] font-medium rounded-[0.5em] gap-x-[0.5em] h-[2.5em]',
-    'a-btn-icon-only': 'font-medium rounded-lg h-[2.5em] w-[2.5em] i:em:text-lg',
+    'a-btn': 'px-[1em] font-medium rounded-[0.5em] gap-x-[0.5em] h-[2.5em] focus:ring',
+    'a-btn-icon-only': 'font-medium rounded-lg h-[2.5em] w-[2.5em] i:em:text-lg focus:ring',
 
     // 👉 Base Input
     'a-base-input-root': 'min-w-[181px] gap-y-1',

--- a/packages/anu-vue/src/presets/theme-default/scss/index.scss
+++ b/packages/anu-vue/src/presets/theme-default/scss/index.scss
@@ -6,6 +6,7 @@
     --a-border-opacity: 0.12;
     --a-overlay-color: 0, 0%, 0%;
     --a-overlay-opacity: 0.35;
+    --a-ring-opacity: 0.5;
 
     --a-primary: 265, 97.7%, 66.3%;
     --a-success: 94.5, 100%, 39.6%;


### PR DESCRIPTION
I would like to work on focus in all element. I've started with the button component.
The focus follow the color of the button.
Here is a screenshot of the concept :

https://user-images.githubusercontent.com/188172/197430725-dd979158-3ced-4287-ad60-bd290fc6bde1.mp4

Just for this screenshot, I added this css in `anu-vue/src/presets/theme-default/scss/index.scss` to get a ring with 2px :
```css
.a-btn:focus {
  --un-ring-width: 2px !important;
}
```
Note that we have to add `!important` mark.

It looks nice, but we cannot use it with css [hex color](https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color) or [named color](https://developer.mozilla.org/en-US/docs/Web/CSS/named-color).
So I didn't change the style in lines [61](https://github.com/jd-solanki/anu/blob/main/packages/anu-vue/src/composables/useLayer.ts#L61) and [67](https://github.com/jd-solanki/anu/blob/main/packages/anu-vue/src/composables/useLayer.ts#L67).

We could use the opacity with the new css feature [relative colors](https://www.w3.org/TR/css-color-5/#relative-colors), but I don't know when it will be supported by major browsers...

In the meantime, I don't know what to do.
What do you think about ?