### PR TITLE
feat(ABtn): Add button loading state

### DIFF
--- a/packages/anu-vue/src/components/btn/ABtn.tsx
+++ b/packages/anu-vue/src/components/btn/ABtn.tsx
@@ -52,6 +52,14 @@ export const ABtn = defineComponent({
      * Disable state of component
      */
     disabled,
+
+    /**
+     * Set loading state
+     */
+    loading: {
+      type: Boolean,
+      default: false,
+    },
   },
   setup(props, { slots, attrs: _ }) {
     const { getLayerClasses } = useLayer()
@@ -64,7 +72,11 @@ export const ABtn = defineComponent({
 
     // FIX: ABtn gets full width if placed inside flex container
     return () => <button class={[props.iconOnly ? 'a-btn-icon-only' : 'a-btn', 'uno-layer-base-text-base whitespace-nowrap inline-flex justify-center items-center', { 'opacity-50 pointer-events-none': props.disabled }, ...classes.value]} style={[...styles.value]}>
-      {props.icon ? <i class={props.icon}></i> : null}{slots.default?.()}{props.appendIcon ? <i class={props.appendIcon}></i> : null}
+      {props.loading && <svg class={['animate-spin h-5 w-5', props.iconOnly ? 'mx-0.5' : '-ml-0.6 mr-0.4']} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+      </svg>}
+      {props.icon && !props.loading ? <i class={props.icon}></i> : null}{slots.default?.()}{props.appendIcon ? <i class={props.appendIcon}></i> : null}
     </button>
   },
 })

--- a/packages/documentation/docs/demos/button/DemoButtonLoading.vue
+++ b/packages/documentation/docs/demos/button/DemoButtonLoading.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { useTimeoutFn } from '@vueuse/core'
+
+const { start, isPending } = useTimeoutFn(
+  () => {}, 2000, { immediate: false },
+)
+</script>
+
+<template>
+  <ABtn
+    :loading="isPending"
+    icon="i-bx-send"
+    @click="start()"
+  >
+    <span>Send</span>
+  </ABtn>
+</template>

--- a/packages/documentation/docs/guide/components/button.md
+++ b/packages/documentation/docs/guide/components/button.md
@@ -129,6 +129,17 @@ You can adjust button roundness using border-radius utilities.
 
 ::::
 
+<!-- 👉 Loading -->
+::::card Loading
+
+You can set loading state to button using `loading` props.
+
+:::code DemoButtonLoading
+<<< @/demos/button/DemoButtonLoading.vue{11}
+:::
+
+::::
+
 <!-- 👉 API -->
 ## API
 


### PR DESCRIPTION
Just added loading state with svg. Works with all colors and variants :


https://user-images.githubusercontent.com/188172/197528663-d959af65-909a-43c4-87ed-6e712cee3cfe.mp4

Tips: for testing, you can change default `loading` props to true.

I haven't supported button size:

![image](https://user-images.githubusercontent.com/188172/197529808-742d982a-f605-43d9-a301-54d0f792dbf5.png)

