### PR TITLE
feat(Btn): fix focus in dark mode and allow opacity

### DIFF
--- a/packages/anu-vue/src/composables/useLayer.ts
+++ b/packages/anu-vue/src/composables/useLayer.ts
@@ -3,7 +3,7 @@ import type { ComponentObjectPropsOptions, Ref } from 'vue'
 import { ref, unref, watch } from 'vue'
 import type { ColorProp } from '@/composables/useProps'
 import { color } from '@/composables/useProps'
-import { contrast } from '@/utils/color'
+import { contrast, hexToRgb } from '@/utils/color'
 
 export const useProps = (propOverrides?: Partial<ComponentObjectPropsOptions>) => {
   const props = {
@@ -58,20 +58,21 @@ export const useLayer = () => {
 
     // If it's not theme color => Set color we received as prop to `--a-layer-color`
     if (!isThemeColor) {
-      styles.push({ '--a-layer-color': propColor })
+      styles.push({ '--a-layer-color': propColor }, { '--un-ring-color': propColor })
 
       // If color isn't theme color & is HEX color => Calculate contrast color => Assign it to `--a-layer-text`
       if (isHexColor) {
         const contrastColor = contrast(propColor)
+        const rgbColor = hexToRgb(propColor)! // isHexColor prevent undefined value here.
 
         styles.push(`--a-layer-text: ${contrastColor}`)
-        styles.push(`--un-ring-color: ${propColor}`)
+        styles.push(`--un-ring-color: rgba(${rgbColor.r}, ${rgbColor.g}, ${rgbColor.b}, var(--un-ring-opacity))`)
       }
     }
 
     // If it's theme color => Use color's CSS var to `--a-layer-color` and to ring color '--un-ring-color'
     else {
-      styles.push({ '--a-layer-color': `hsla(var(--a-${propColor}),var(--un-bg-opacity))` }, { '--un-ring-color': `hsl(var(--a-${propColor}))` })
+      styles.push({ '--a-layer-color': `hsla(var(--a-${propColor}),var(--un-bg-opacity))` }, { '--un-ring-color': `hsla(var(--a-${propColor}), var(--un-ring-opacity))` })
 
       // ℹ️ We need to set un-bg-opacity just like UnoCSS class
       classes.push('[--un-bg-opacity:1]')

--- a/packages/anu-vue/src/presets/theme-default/scss/index.scss
+++ b/packages/anu-vue/src/presets/theme-default/scss/index.scss
@@ -115,10 +115,15 @@ hr {
 
 // Remove outline
 .a-btn,
+.a-btn-icon-only,
 input,
 select,
 textarea {
-  &:focus {
-    outline: none;
+  --un-ring-opacity: 1;
+
+  &:focus, &:focus-visible {
+    outline: var(--un-ring-width) solid var(--un-ring-color);
+    outline-offset: var(--un-ring-offset-width);
+    box-shadow: none !important;
   }
 }


### PR DESCRIPTION
This pull request fixes focus on dark mode as mentioned in [#53](https://github.com/jd-solanki/anu/pull/53#issuecomment-1301007234).
We can't rely on unocss ring because it use box-shadow. The offset of the box-shadow is done with a white shadow, which broke design in dark mode.
So, I use only outline css style. We can ever use `ring-width`, `ring-color` and `ring-offset`.
I also added opacity. So we can use this kind of classes to customize the ring :
```html
<ABtn
    color="success"
    class="focus-visible:ring-4 ring-offset-6 ring-opacity-50"
>
    Success
</ABtn>
```
Opacity also works with HexColor.