### PR TITLE
build: Simplifying type generation process

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "docs:dev": "nr --filter @anu-vue/documentation dev",
     "docs:build": "nr --filter anu-vue build && nr --filter @anu-vue/documentation build",
     "clean": "rimraf packages/anu-vue/dist",
-    "deep-clean": "rimraf node_modules packages/anu-vue/node_modules packages/anu-vue/dist packages/documentation/node_modules",
     "release": "bumpp package.json packages/anu-vue/package.json --execute 'nr --filter anu-vue build' && na --filter anu-vue publish --no-git-checks",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "nr --filter anu-vue build",
     "docs:dev": "nr --filter @anu-vue/documentation dev",
     "docs:build": "nr --filter anu-vue build && nr --filter @anu-vue/documentation build",
-    "clean": "rimraf node_modules packages/anu-vue/node_modules packages/anu-vue/dist packages/documentation/node_modules",
+    "clean": "rimraf packages/anu-vue/dist",
+    "deep-clean": "rimraf node_modules packages/anu-vue/node_modules packages/anu-vue/dist packages/documentation/node_modules",
     "release": "bumpp package.json packages/anu-vue/package.json --execute 'nr --filter anu-vue build' && na --filter anu-vue publish --no-git-checks",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"

--- a/packages/anu-vue/package.json
+++ b/packages/anu-vue/package.json
@@ -34,11 +34,11 @@
   "files": [
     "dist"
   ],
-  "types": "dist",
+  "types": "dist/types",
   "scripts": {
     "dev": "nr gen-comp-meta && vite build --watch",
     "gen-comp-meta": "na tsx ../../scripts/gen-component-meta.ts",
-    "build": "nr gen-comp-meta && vite build && vue-tsc --emitDeclarationOnly --declaration",
+    "build": "nr gen-comp-meta && vite build",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/packages/anu-vue/vite.config.ts
+++ b/packages/anu-vue/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
       name: 'anu-vue',
       fileName: 'anu-vue',
     },
+    outDir: 'dist',
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled
       // into your library
@@ -29,7 +30,10 @@ export default defineConfig({
       },
     },
   },
-  plugins: [vue(), vueJsx(), dts()],
+  plugins: [vue(), vueJsx(), dts({
+    outputDir: 'dist/types',
+    insertTypesEntry: true,
+  })],
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),


### PR DESCRIPTION
Few suggested changes:
* Updated `npm run clean` script: it will **not** remove node_modules folder, only removes dist folder. Advantage: you can avoid lengthy install process after `npm run clean`
* Added a new `deep-clean` script, which does remove the node_modules, but TBH I have never seen such approach in practice (aka removal of node_modules) elsewhere, so it's up to you whether to keep this or remove it as it's not really needed
* In the build process we don't need `tsc --emitDeclarationOnly...` as we have the `dts()` plugin in place which generates the d.ts files - advantage is a faster build and build script won't pollute the source folders with generated d.ts files
* I suggest following the canonical practice and expose the types in the `types` folder. dts() plugin now generates types in that folder.

LMK what you think