### PR TITLE
fix: icon glitch in Firefox

### DIFF
--- a/packages/anu-vue/src/index.ts
+++ b/packages/anu-vue/src/index.ts
@@ -42,5 +42,6 @@ export const presetIconExtraProperties = {
   'vertical-align': 'text-top',
   'flex-shrink': '0',
   'display': 'inline-block',
+  'backface-visibility': 'hidden',
 }
 

--- a/packages/preset-theme-default/src/scss/index.scss
+++ b/packages/preset-theme-default/src/scss/index.scss
@@ -104,6 +104,11 @@ h6 {
 
 // 👉 Misc
 
+// Prevent icon glitch in firefox
+* {
+  backface-visibility: hidden;
+}
+
 @keyframes shake {
   0%   {transform: translateX(0);}
   25%  {transform: translateX(1px);}

--- a/packages/preset-theme-default/src/scss/index.scss
+++ b/packages/preset-theme-default/src/scss/index.scss
@@ -104,11 +104,6 @@ h6 {
 
 // 👉 Misc
 
-// Prevent icon glitch in firefox
-* {
-  backface-visibility: hidden;
-}
-
 @keyframes shake {
   0%   {transform: translateX(0);}
   25%  {transform: translateX(1px);}


### PR DESCRIPTION
In Firefox, when we use css `transform`, it causes a little glitch on icons :
![image](https://user-images.githubusercontent.com/188172/201937764-8b6acb83-08c8-4aeb-b468-503f3db5d96b.png)

Adding `backface-visibility: hidden;` prevent this.

Example code to reproduce this behaviour :
```js
<ABtn
  variant="text"
  icon="i-mdi-plus-circle"
  icon-only
  class="transform children:transition children:rotate-45"
/>
```