### PR TITLE
fix: `:host` selector for shadow-root

### DIFF
--- a/packages/anu-vue/src/presets/theme-default/scss/index.scss
+++ b/packages/anu-vue/src/presets/theme-default/scss/index.scss
@@ -8,7 +8,7 @@ body {
 
 $body-color: hsla(var(--a-base-color), 0.68);
 
-:root, :host {
+*, ::before, ::after {
     --a-base-color: 0, 10%, 20%;
     --a-layer: 0, 0%, 100%;
     --a-border-opacity: 0.12;
@@ -65,7 +65,7 @@ $body-color: hsla(var(--a-base-color), 0.68);
     // !SECTION
 }
 
-:root.dark, :host.dark {
+.dark *, .dark ::before, .dark ::after {
   --a-base-color: 0, 0%, 94%;
   --a-layer: 0, 0%, 12%;
   --a-overlay-opacity: 0.5;

--- a/packages/anu-vue/src/presets/theme-default/scss/index.scss
+++ b/packages/anu-vue/src/presets/theme-default/scss/index.scss
@@ -8,7 +8,7 @@ body {
 
 $body-color: hsla(var(--a-base-color), 0.68);
 
-:root {
+:root, :host {
     --a-base-color: 0, 10%, 20%;
     --a-layer: 0, 0%, 100%;
     --a-border-opacity: 0.12;
@@ -65,7 +65,7 @@ $body-color: hsla(var(--a-base-color), 0.68);
     // !SECTION
 }
 
-:root.dark {
+:root.dark, :host.dark {
   --a-base-color: 0, 0%, 94%;
   --a-layer: 0, 0%, 12%;
   --a-overlay-opacity: 0.5;


### PR DESCRIPTION
I'm building a web extension with the awesome [vitesse-webext](https://github.com/antfu/vitesse-webext) starter template.

I can import Anu components in the contentScripts (the script inject in the page by the web extension).
But all `:root` variables aren't provided by the `#shadow-root` injected.

I know unocss use `*, ::before, ::after`  [here](https://github.com/unocss/unocss/blob/main/packages/reset/antfu.css#L1).

I tried to change `:root` line [#L11](https://github.com/jd-solanki/anu/blob/main/packages/anu-vue/src/presets/theme-default/scss/index.scss#L11) by `*, ::before, ::after` and dark mode line [#L68](https://github.com/jd-solanki/anu/blob/main/packages/anu-vue/src/presets/theme-default/scss/index.scss#L68) by `.dark *, .dark ::before, .dark ::after` and everything seems working as expected.

`*, ::before, ::after`  seems a little bit hacky and I don't know implication of this change.

So I tried with the [`:host` selector](https://developer.mozilla.org/en-US/docs/Web/CSS/:host_function).
I replaced line [#L11](https://github.com/jd-solanki/anu/blob/main/packages/anu-vue/src/presets/theme-default/scss/index.scss#L11) by `:root, :host` and dark mode line [#L68](https://github.com/jd-solanki/anu/blob/main/packages/anu-vue/src/presets/theme-default/scss/index.scss#L68) by `:root.dark, :host.dark` and it works in the shadow-root. I think it's less risky like that.