### PR TITLE
fix(list): make list item clickable if click event is used

### DIFF
--- a/docs/demos/list/DemoListVModelSupport.vue
+++ b/docs/demos/list/DemoListVModelSupport.vue
@@ -43,7 +43,7 @@ const slotSelection = ref(0)
             :value="index"
             :disable="item.disable"
             :is-active="slotSelection === index"
-            @click="item => handleListItemClick(item)"
+            @click="handleListItemClick(item, index)"
           />
         </template>
         <template #after>

--- a/docs/guide/components/list.md
+++ b/docs/guide/components/list.md
@@ -52,7 +52,7 @@ Just like `avatar-append`, you can also use `icon-append` to render the action b
 <!-- 👉 `v-model` Support -->
 ::::card `v-model` Support
 
-`AList` also support `v-model`. Use any value other than `null` to enable the `v-model` support.
+`AList` also support `v-model`. Use any value other than `undefined` to enable the `v-model` support.
 
 If you use `items` prop on `AList` and don't provide `value` property to each list item, `AList` will emit list item's index as selected value.
 

--- a/packages/anu-vue/src/components/list-item/AListItem.tsx
+++ b/packages/anu-vue/src/components/list-item/AListItem.tsx
@@ -1,5 +1,5 @@
 import type { PropType } from 'vue'
-import { computed, defineComponent, getCurrentInstance, toRef } from 'vue'
+import { computed, defineComponent, toRef } from 'vue'
 import { ATypography } from '../typography'
 import { AAvatar } from '@/components/avatar'
 import type { ConfigurableValue } from '@/composables/useConfigurable'
@@ -63,8 +63,8 @@ export const AListItem = defineComponent({
       default: false,
     },
   },
-  emits: ['click', 'click:icon', 'click:avatar', 'click:iconAppend', 'click:avatarAppend'],
-  setup(props, { slots, emit }) {
+  emits: ['click:icon', 'click:avatar', 'click:iconAppend', 'click:avatarAppend'],
+  setup(props, { slots, emit, attrs }) {
     const { getLayerClasses } = useLayer()
 
     // ℹ️ Reduce the size of title to 1rem. We did the same in ACard as well.
@@ -73,11 +73,6 @@ export const AListItem = defineComponent({
       _titleProp.value.classes = [..._titleProp.value.classes, 'uno-layer-base-text-base']
     else
       _titleProp.value.classes += ' uno-layer-base-text-base'
-
-    // Handle list item click
-    const handleListItemClick = () => {
-      emit('click', props.value)
-    }
 
     // useLayer
     const { styles, classes } = getLayerClasses(
@@ -93,13 +88,12 @@ export const AListItem = defineComponent({
           class={[
             'a-list-item',
             { 'opacity-50 pointer-events-none': props.disable },
-            props.value !== undefined || !!getCurrentInstance()?.vnode.props?.onClick
+            props.value !== undefined || attrs.onClick
               ? [...classes.value, 'cursor-pointer']
               : '',
             'flex items-center gap-$a-list-item-gap m-$a-list-item-margin p-$a-list-item-padding min-h-$a-list-item-min-height',
           ]}
           data-color={props.color}
-          onClick={handleListItemClick}
           style={[...styles.value]}
         >
           {/* 👉 Slot: prepend */}

--- a/packages/anu-vue/src/components/list-item/AListItem.tsx
+++ b/packages/anu-vue/src/components/list-item/AListItem.tsx
@@ -1,5 +1,5 @@
 import type { PropType } from 'vue'
-import { computed, defineComponent, toRef } from 'vue'
+import { computed, defineComponent, getCurrentInstance, toRef } from 'vue'
 import { ATypography } from '../typography'
 import { AAvatar } from '@/components/avatar'
 import type { ConfigurableValue } from '@/composables/useConfigurable'
@@ -93,7 +93,7 @@ export const AListItem = defineComponent({
           class={[
             'a-list-item',
             { 'opacity-50 pointer-events-none': props.disable },
-            props.value !== undefined
+            props.value !== undefined || !!getCurrentInstance()?.vnode.props?.onClick
               ? [...classes.value, 'cursor-pointer']
               : '',
             'flex items-center gap-$a-list-item-gap m-$a-list-item-margin p-$a-list-item-padding min-h-$a-list-item-min-height',

--- a/packages/anu-vue/src/components/list/AList.tsx
+++ b/packages/anu-vue/src/components/list/AList.tsx
@@ -76,10 +76,9 @@ export const AList = defineComponent({
     })
 
     // const isActive = computed(() => options.value[itemIndex].isSelected)
-    const handleListItemClick = (item: any) => {
-      const emitValue = item.value ?? item
-      emit('update:modelValue', emitValue)
-      selectListItem(emitValue)
+    const handleListItemClick = (item: ListItem, index: number) => {
+      selectListItem(item.value || index)
+      emit('update:modelValue', value.value)
     }
 
     // 👉 Return
@@ -103,7 +102,7 @@ export const AList = defineComponent({
               avatarAppend={props.avatarAppend}
               iconAppend={props.iconAppend}
               is-active={options.value[index].isSelected}
-              onClick={handleListItemClick}
+              onClick={item.value || (props.modelValue !== undefined) ? () => handleListItemClick(item, index) : null}
               v-slots={{
                 prepend: slots.prepend ? () => slots.prepend?.({ item, index }) : null,
                 item: slots.item ? () => slots.item?.({ item, index }) : null,


### PR DESCRIPTION
This change avoids adding `class="states:10 cursor-pointer"` or `value` props to `AListItem` to make it highlightable.
See here this [comment](https://github.com/jd-solanki/anu/issues/74#issuecomment-1331463407).