### PR TITLE
fix(@anu-vue/nuxt): fixed import issue

### DIFF
--- a/packages/anu-nuxt/src/runtime/plugin.ts
+++ b/packages/anu-nuxt/src/runtime/plugin.ts
@@ -1,8 +1,0 @@
-import { anu } from 'anu-vue'
-import { defineNuxtPlugin, useRuntimeConfig } from '#app'
-
-export default defineNuxtPlugin(nuxtApp => {
-  const config = useRuntimeConfig()?.public?.anu || {}
-  nuxtApp.vueApp.use(anu, config)
-})
-


### PR DESCRIPTION
After further testing on the @anu-vue/nuxt-edge, I found there is a wired issue with resolving certain `#app` from nuxt. A quick fix in the meantime is to make it a virtual inline plugin template. I tested this by building  then copying it to the dist folder in the `node_modules/@anu-vue/nuxt/` everything seems to work as intended now. 

I will look into this as this seems like an upstream bug -- I will look into in the meantime to find a fix.

Thanks,
Christian.