### PR TITLE
fix(@anu-vue/nuxt): Auto Import and Enable Icons

### DIFF
--- a/packages/anu-nuxt/src/module.ts
+++ b/packages/anu-nuxt/src/module.ts
@@ -6,7 +6,7 @@ import {
 } from '@nuxt/kit'
 import presetIcons from '@unocss/preset-icons'
 import presetUno from '@unocss/preset-uno'
-import { Composables as AnuComposables, presetAnu, presetIconExtraProperties } from 'anu-vue'
+import { composables as AnuComposables, presetAnu, presetIconExtraProperties } from 'anu-vue'
 
 import { name, version } from '../package.json'
 
@@ -106,8 +106,10 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     // Add Auto Completions for Anu Composables
+    const composablesToExclude = ['useProp']
+
     Object.keys(AnuComposables)
-      .filter(key => key.includes('use') && key !== 'useProp')
+      .filter(key => key.includes('use') && !composablesToExclude.includes(key))
       .forEach(name => {
         addImports({
           name,

--- a/packages/anu-vue/src/index.ts
+++ b/packages/anu-vue/src/index.ts
@@ -1,7 +1,6 @@
 import { defu } from 'defu'
 import type { App } from 'vue'
 import * as components from './components'
-import * as composables from './composables'
 import { provideAppSpacing } from '@/composables/useSpacing'
 import './scss/index.scss'
 
@@ -32,10 +31,10 @@ const plugin = {
 export { AnuComponentResolver } from './componentResolver'
 export * from './components'
 export * from './composables'
+export * as composables from './composables'
 export { presetAnu } from './preset'
 export * from './symbols'
 export { plugin as anu }
-export const Composables = composables
 export const presetIconExtraProperties = {
   'height': '1.2em',
   'width': '1.2em',

--- a/packages/anu-vue/src/index.ts
+++ b/packages/anu-vue/src/index.ts
@@ -1,6 +1,7 @@
 import { defu } from 'defu'
 import type { App } from 'vue'
 import * as components from './components'
+import * as composables from './composables'
 import { provideAppSpacing } from '@/composables/useSpacing'
 import './scss/index.scss'
 
@@ -34,6 +35,7 @@ export * from './composables'
 export { presetAnu } from './preset'
 export * from './symbols'
 export { plugin as anu }
+export const Composables = composables
 export const presetIconExtraProperties = {
   'height': '1.2em',
   'width': '1.2em',


### PR DESCRIPTION
# Fixes

- Instead of doing scripts to get composables, Instead from the anu-vue package export Composables as const to then add them within the nuxt 3 module to then add dynamically.
  - To make this a easier process it would be then to create another export within package.json to have a path specific to the composables.
- Enable Uno Preset Icon Preset by default and set the anu-preset icon props if not defined.
- Fixed an issue where the icon object wouldn't be able to get passed within testing.