### PR TITLE
fix(ui/form): prevent misalignment

### DIFF
--- a/docs/components/ui/form/UIFormCreditCardPayment.vue
+++ b/docs/components/ui/form/UIFormCreditCardPayment.vue
@@ -30,11 +30,13 @@ const creditCardDetails = reactive({
           v-model.trim="creditCardDetails.expiration"
           label="Expiration"
           placeholder="23/12"
+          class="justify-end"
         />
         <AInput
           v-model.trim.number="creditCardDetails.cvc"
           label="CVV"
           placeholder="987"
+          class="justify-end"
           type="number"
         />
 


### PR DESCRIPTION
In case of label with two lines, this fix prevents misalignment of the inputs.

Before : 

![image](https://user-images.githubusercontent.com/188172/212445010-8742c0c8-bd7d-4b0e-a12f-5cc21da9679a.png)

After :

![image](https://user-images.githubusercontent.com/188172/212445025-31c4550b-7190-408d-a47e-8a0f37e59235.png)

Works in `sm` screen.