### PR TITLE
chore: add types field to exports in package.json

### DIFF
--- a/packages/anu-vue/package.json
+++ b/packages/anu-vue/package.json
@@ -26,6 +26,7 @@
   "module": "./dist/anu-vue.js",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/anu-vue.js",
       "require": "./dist/anu-vue.umd.cjs"
     },


### PR DESCRIPTION
This will help other developers use and consume the correct type definitions for the exported modules.

reference: https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing