### PR TITLE
feat(config): global config support

### DIFF
--- a/packages/anu-vue/src/components/config-provider/config-provider-props.ts
+++ b/packages/anu-vue/src/components/config-provider/config-provider-props.ts
@@ -1,0 +1,10 @@
+import type { ExtractPropTypes } from 'vue'
+import { defaultBaseZIndex } from '@/composables/useZIndex'
+
+export const configProviderProps = {
+  zIndex: {
+    type: Number,
+    default: defaultBaseZIndex,
+  },
+}
+export type ConfigProviderProps = ExtractPropTypes<typeof configProviderProps>

--- a/packages/anu-vue/src/components/config-provider/config-provider.ts
+++ b/packages/anu-vue/src/components/config-provider/config-provider.ts
@@ -1,0 +1,17 @@
+import { defineComponent, renderSlot } from 'vue'
+import { provideConfig } from '@/composables/useConfig'
+import { configProviderProps } from '@/components/config-provider/config-provider-props'
+
+const ConfigProvider = defineComponent({
+  name: 'AConfigProvider',
+  props: configProviderProps,
+  setup(props, { slots }) {
+    const config = provideConfig(props)
+
+    return () => renderSlot(slots, 'default', { config: config?.value })
+  },
+})
+
+export type ConfigProviderInstance = InstanceType<typeof ConfigProvider>
+
+export default ConfigProvider

--- a/packages/anu-vue/src/components/floating/AFloating.vue
+++ b/packages/anu-vue/src/components/floating/AFloating.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
 import { autoUpdate, useFloating } from '@floating-ui/vue'
 import { onClickOutside, useEventListener, useMounted } from '@vueuse/core'
+import type { CSSProperties } from 'vue'
 import { ref } from 'vue'
 import type { FloatingEvents } from './events'
 import { floatingProps } from './props'
 import { useTeleport } from '@/composables/useTeleport'
+import { useZIndex } from '@/composables/useZIndex'
 
 const props = defineProps(floatingProps)
 
@@ -45,6 +47,17 @@ const { x, y, strategy } = useFloating(toRef(props, 'referenceEl'), refFloating,
   placement: toRef(props, 'placement'),
   middleware: _middleware,
   whileElementsMounted: autoUpdate,
+})
+
+const { nextZIndex } = useZIndex()
+const zIndex = nextZIndex()
+
+const contentStyle = computed<CSSProperties>(() => {
+  return {
+    top: `${unref(y) ?? 0}px`,
+    left: `${unref(x) ?? 0}px`,
+    zIndex,
+  }
 })
 
 // onMounted(() => {
@@ -119,10 +132,7 @@ defineExpose({
         v-bind="$attrs"
         ref="refFloating"
         class="a-floating transform"
-        :style="{
-          top: `${y ?? 0}px`,
-          left: `${x ?? 0}px`,
-        }"
+        :style="contentStyle"
         :class="strategy"
       >
         <slot />

--- a/packages/anu-vue/src/composables/useConfig.ts
+++ b/packages/anu-vue/src/composables/useConfig.ts
@@ -1,0 +1,54 @@
+import type { MaybeRef } from '@vueuse/core'
+import type { App, InjectionKey, Ref } from 'vue'
+import { getCurrentInstance, provide } from 'vue'
+import { zIndexContextKey } from '@/composables/useZIndex'
+import type { ConfigProviderProps } from '@/components/config-provider/config-provider-props'
+
+export type ConfigProviderContext = Partial<ConfigProviderProps>
+export const configProviderContextKey: InjectionKey<
+  Ref<ConfigProviderContext>
+> = Symbol('AnuConfigProviderKey')
+
+// Storing this value is to be able to use useConfig outside of the component.
+const globalConfig = ref<ConfigProviderContext>()
+
+export function useConfig() {
+  return getCurrentInstance()
+    ? inject(configProviderContextKey, globalConfig)
+    : globalConfig
+}
+
+export function provideConfig(
+  config: MaybeRef<ConfigProviderProps>,
+  app?: App,
+) {
+  const provideFn = getProvideFunction(app)
+  if (!provideFn)
+    return
+
+  const context = computed(() => unref(config))
+
+  provideFn(configProviderContextKey, context)
+
+  provideFn(zIndexContextKey, computed(() => context.value.zIndex))
+
+  if (!globalConfig.value)
+    globalConfig.value = context.value
+
+  return context
+}
+
+function getProvideFunction(app?: App) {
+  const currentInstance = getCurrentInstance()
+  const useInComponent = !!currentInstance
+
+  if (useInComponent)
+    return provide
+
+  if (app)
+    return app.provide
+
+  console.warn('provideConfig() can only be used inside setup().')
+
+  return undefined
+}

--- a/packages/anu-vue/src/composables/useZIndex.ts
+++ b/packages/anu-vue/src/composables/useZIndex.ts
@@ -1,0 +1,35 @@
+import type { InjectionKey, Ref } from 'vue'
+import { computed, inject, ref, unref } from 'vue'
+import { isNumber } from '@vueuse/core'
+
+export const defaultBaseZIndex = 2000 as const
+
+const zIndexCounter = ref(0)
+
+export const zIndexContextKey: InjectionKey<Ref<number | undefined>> = Symbol('zIndexContextKey')
+
+export function useZIndex() {
+  const injectedZIndex = inject(zIndexContextKey, undefined)
+
+  const baseZIndex = computed(() => {
+    const injectedZIndexValue = unref(injectedZIndex)
+
+    return isNumber(injectedZIndexValue)
+      ? injectedZIndexValue
+      : defaultBaseZIndex
+  })
+
+  const activeZIndex = computed(() => baseZIndex.value + zIndexCounter.value)
+
+  const nextZIndex = () => {
+    zIndexCounter.value++
+
+    return activeZIndex.value
+  }
+
+  return {
+    baseZIndex,
+    activeZIndex,
+    nextZIndex,
+  }
+}

--- a/packages/anu-vue/src/plugin.ts
+++ b/packages/anu-vue/src/plugin.ts
@@ -4,6 +4,8 @@ import type { App } from 'vue'
 import * as components from '@/components'
 import { useAnu } from '@/composables/useAnu'
 import { ANU_CONFIG } from '@/symbols'
+import { provideConfig } from '@/composables/useConfig'
+import { defaultBaseZIndex } from '@/composables/useZIndex'
 
 export type ThemeColors = 'primary' | 'success' | 'info' | 'warning' | 'danger'
 export type DefaultThemes = 'light' | 'dark'
@@ -20,11 +22,13 @@ export interface PluginOptions {
   registerComponents: boolean
   initialTheme: keyof ConfigThemes
   themes: ConfigThemes
+  zIndex: number
 }
 
 const configDefaults: PluginOptions = {
   registerComponents: true,
   initialTheme: 'light',
+  zIndex: 2000,
   themes: {
     light: {
       class: '',
@@ -74,6 +78,9 @@ export const plugin = {
     }
 
     app.provide(ANU_CONFIG, config)
+
+    if (options)
+      provideConfig({ zIndex: options.zIndex || defaultBaseZIndex }, app)
 
     // Initialize Anu instance with config values
     useAnu({

--- a/packages/anu-vue/test/AConfigProvider.test.tsx
+++ b/packages/anu-vue/test/AConfigProvider.test.tsx
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent, nextTick, ref } from 'vue'
+import ConfigProvider from '../src/components/config-provider/config-provider'
+import { useConfig } from '../src/composables/useConfig'
+
+describe('ConfigProvider.vue', () => {
+  it('provides config to child components', () => {
+    const config = ref()
+    const zIndex = 1000
+    const TestComponent = defineComponent({
+      setup() {
+        config.value = useConfig().value
+
+        return () => <div></div>
+      },
+    })
+
+    mount(() =>
+      <ConfigProvider zIndex={zIndex}>
+        <TestComponent />
+      </ConfigProvider>,
+    )
+    expect(config.value.zIndex).toBe(zIndex)
+  })
+
+  it('updates provided config when value changes', async () => {
+    const config = ref()
+    const zIndex = ref(1000)
+    const TestComponent = defineComponent({
+      setup() {
+        config.value = useConfig().value
+
+        return () => <div></div>
+      },
+    })
+    mount(() =>
+      <ConfigProvider zIndex={zIndex.value}>
+        <TestComponent></TestComponent>
+      </ConfigProvider>,
+    )
+
+    zIndex.value = 3000
+    await nextTick()
+
+    expect(config.value.zIndex).toBe(3000)
+  })
+
+  it('provides nested child config correctly', async () => {
+    const parentZIndex = 2000
+    const childZIndex = 3000
+    const nestedConfig = ref()
+
+    const NestedChildComponent = defineComponent({
+      setup() {
+        nestedConfig.value = useConfig().value
+
+        return () => <div></div>
+      },
+    })
+
+    const ChildComponent = defineComponent({
+      components: { ConfigProvider, NestedChildComponent },
+      setup() {
+        return () => (
+          <ConfigProvider zIndex={childZIndex}>
+            <NestedChildComponent />
+          </ConfigProvider>
+        )
+      },
+    })
+
+    const ParentComponent = defineComponent({
+      components: { ConfigProvider, ChildComponent },
+      setup() {
+        return () => (
+          <ConfigProvider zIndex={parentZIndex}>
+            <ChildComponent />
+          </ConfigProvider>
+        )
+      },
+    })
+
+    mount(ParentComponent)
+    await nextTick()
+    expect(nestedConfig.value.zIndex).toBe(childZIndex)
+  })
+})

--- a/packages/anu-vue/test/composables/useZIndex.test.ts
+++ b/packages/anu-vue/test/composables/useZIndex.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import type { ComponentPublicInstance } from 'vue'
+import { defineComponent, nextTick, ref } from 'vue'
+import type { VueWrapper } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
+import { defaultBaseZIndex, useZIndex, zIndexContextKey } from '../../src/composables/useZIndex'
+
+describe('useZIndex', () => {
+  let wrapper: VueWrapper<ComponentPublicInstance>
+
+  const mountComponent = (provideZIndex?: number) => mount(
+    defineComponent({
+      setup(_, { expose }) {
+        const zIndex = useZIndex()
+        expose(zIndex)
+      },
+    }),
+    {
+      global: {
+        provide: {
+          [zIndexContextKey]: ref(provideZIndex),
+        },
+      },
+    },
+  )
+
+  it('should have the default baseZIndex when no custom zIndex is provided', async () => {
+    wrapper = mountComponent()
+    await nextTick()
+    expect(wrapper.vm.baseZIndex).toBe(defaultBaseZIndex)
+  })
+
+  it('should use the provided custom zIndex', async () => {
+    const zIndex = 1000
+    wrapper = mountComponent(zIndex)
+    const { vm } = wrapper
+    await nextTick()
+    expect(vm.baseZIndex).toBe(zIndex)
+  })
+
+  it('should increment zIndex correctly', async () => {
+    wrapper = mountComponent()
+    const { vm } = wrapper
+    await nextTick()
+    const initialZIndex = vm.activeZIndex
+    const incrementedZIndex = vm.nextZIndex()
+    expect(incrementedZIndex).toBe(initialZIndex + 1)
+    expect(vm.activeZIndex).toBe(initialZIndex + 1)
+  })
+})


### PR DESCRIPTION
We can now configure the zIndex property in the following two ways:
- `app.use(anu)`
```ts
// main.ts
app.use(anu, { zIndex:3000 })
```
- use `ConfigProvider` component
```vue
// global
<AConfigProvider :zIndex="zIndex">
  <RouterView/>
<AConfigProvider/>

const zIndex = ref(3000)

// component scope
<AConfigProvider zIndex="2000">
   <ABtn>
     <ATooltip />
   </ABtn>
<AConfigProvider />
```