### PR TITLE
chore: replace deprecated `vueuse` API

### DIFF
--- a/packages/anu-vue/src/composables/useCheckbox.ts
+++ b/packages/anu-vue/src/composables/useCheckbox.ts
@@ -1,5 +1,6 @@
 import type { MaybeRefOrGetter } from '@vueuse/core'
 import type { ComponentObjectPropsOptions, PropType } from 'vue'
+import { toValue } from 'vue'
 
 export type CheckboxModelValue = null | string | number | boolean | unknown[]
 

--- a/packages/anu-vue/src/composables/useCheckbox.ts
+++ b/packages/anu-vue/src/composables/useCheckbox.ts
@@ -59,12 +59,12 @@ export function useCheckbox<Name extends string>(
   cycleIndeterminate: MaybeRefOrGetter<boolean> = false,
 ) {
   const handleModelValueChange = () => {
-    const _cycleIndeterminate = resolveUnref(cycleIndeterminate)
-    const _modelValue = resolveUnref(modelValue)
+    const _cycleIndeterminate = toValue(cycleIndeterminate)
+    const _modelValue = toValue(modelValue)
 
-    const _checkedValue = resolveUnref(checkedValue)
-    const _uncheckedValue = resolveUnref(uncheckedValue)
-    const _indeterminateValue = resolveUnref(indeterminateValue)
+    const _checkedValue = toValue(checkedValue)
+    const _uncheckedValue = toValue(uncheckedValue)
+    const _indeterminateValue = toValue(indeterminateValue)
 
     const cycleInitialValue = Array.isArray(_modelValue)
       ? (_modelValue.includes(_checkedValue) ? _checkedValue : _uncheckedValue)
@@ -96,8 +96,8 @@ export function useCheckbox<Name extends string>(
 
   const isChecked = computed({
     get: () => {
-      const _modelValue = resolveUnref(modelValue)
-      const _checkedValue = resolveUnref(checkedValue)
+      const _modelValue = toValue(modelValue)
+      const _checkedValue = toValue(checkedValue)
 
       if (Array.isArray(_modelValue))
         return _modelValue.includes(_checkedValue)
@@ -108,8 +108,8 @@ export function useCheckbox<Name extends string>(
   })
 
   const isIndeterminate = computed(() => {
-    const _modelValue = resolveUnref(modelValue)
-    const _indeterminateValue = resolveUnref(indeterminateValue)
+    const _modelValue = toValue(modelValue)
+    const _indeterminateValue = toValue(indeterminateValue)
 
     if (Array.isArray(_modelValue))
       return _modelValue.includes(_indeterminateValue)

--- a/packages/anu-vue/src/composables/useConfigurable.ts
+++ b/packages/anu-vue/src/composables/useConfigurable.ts
@@ -1,5 +1,5 @@
 import type { MaybeRef } from '@vueuse/core'
-import { resolveUnref } from '@vueuse/core'
+import { toValue } from '@vueuse/core'
 import { computed } from 'vue'
 
 // ℹ️ We might need generic here in future
@@ -12,7 +12,7 @@ export type ConfigurableValue = undefined | ContentType | [ContentType, ClassAtt
 
 export function useConfigurable(value: MaybeRef<ConfigurableValue>) {
   return computed(() => {
-    const _value = resolveUnref(value)
+    const _value = toValue(value)
 
     const [content, classes, attrs] = _value === undefined
       ? []

--- a/packages/anu-vue/src/composables/useTypographyColor.ts
+++ b/packages/anu-vue/src/composables/useTypographyColor.ts
@@ -1,5 +1,5 @@
 import type { MaybeRefOrGetter } from '@vueuse/core'
-import { resolveUnref } from '@vueuse/core'
+import { toValue } from '@vueuse/core'
 import type { ColorProp } from './useProps'
 import { colord } from '@/utils/colord'
 import { isThemeColor } from '@/composables/useColor'
@@ -43,8 +43,8 @@ export function useTypographyColor(color: MaybeRefOrGetter<ColorProp | null>, va
   const typographyClasses = ref<string[]>([])
   const typographyStyles = ref<string[]>([])
 
-  const _color = resolveUnref(color)
-  const _variant = resolveUnref(variant)
+  const _color = toValue(color)
+  const _variant = toValue(variant)
   const _isThemeColor = isThemeColor(_color)
 
   watch([() => color, () => variant], () => {


### PR DESCRIPTION
`resolveUnref` has been renamed to `toValue`, you can check the [release doc](https://github.com/vueuse/vueuse/releases/tag/v10.0.0) here 