### PR TITLE
docs: split package managers

### DIFF
--- a/docs/guide/getting-started/integrations/nuxt.md
+++ b/docs/guide/getting-started/integrations/nuxt.md
@@ -3,15 +3,13 @@
 :::card Installation
 
 1. Instead of installing `anu-vue` package, install `@anu-vue/nuxt`.
-
     ```bash
-    # pnpm
     pnpm add @anu-vue/nuxt && pnpm add -D @unocss/nuxt
-
-    # yarn
+    ```
+    ```bash
     yarn add @anu-vue/nuxt && yarn add -D @unocss/nuxt
-
-    # npm
+    ```
+    ```bash
     npm install @anu-vue/nuxt && npm install -D @unocss/nuxt
     ```
 


### PR DESCRIPTION
A little refactoring that splits package managers listed in the Nuxt installation page, for easier copy and pasting to the terminal. 😅

![repro-anu](https://github.com/jd-solanki/anu/assets/38413630/fb12a9aa-7ae8-41c3-9a6c-6f6ef0ba0ee2)
